### PR TITLE
feat: closes #16 - add subscription status enum

### DIFF
--- a/src/components/subscriber/Subscriber.tsx
+++ b/src/components/subscriber/Subscriber.tsx
@@ -4,6 +4,7 @@ import { Subscribers } from '@/xata'
 import { updateSubscriberPreferences } from '@/lib/queries'
 import toast from 'react-hot-toast'
 import CategoryCheckbox from './CategoryCheckbox'
+import { Status } from '@/types/Types'
 
 export default function Subscriber({
   subscriber,
@@ -52,7 +53,7 @@ export default function Subscriber({
       toolNotifications: subscribedStatus,
       conferenceNotifications: subscribedStatus,
       miscNotifications: subscribedStatus,
-      status: subscribedStatus ? 'subscribed' : 'unsubscribed',
+      status: subscribedStatus ? Status.SUBSCRIBED : Status.UNSUBSCRIBED,
     }
 
     // Update the state

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -1,5 +1,6 @@
 'use server'
 import { NewSubscriberData } from '@/types/Types'
+import { Status } from '@/types/Types'
 
 import { getXataClient, DealsRecord, Subscribers } from '@/xata'
 const xataClient = getXataClient()
@@ -51,7 +52,7 @@ export async function getAllSubscribers(): Promise<Subscribers[]> {
 export async function updateSubscriberToVerified(id: string) {
   const data = await xataClient.db.subscribers.update(id, {
     verified: true,
-    status: 'subscribed',
+    status: Status.SUBSCRIBED,
   })
 
   return data
@@ -80,7 +81,7 @@ export async function updateSubscriberPreferences(
 
   const subscriber = {
     ...subscriberData,
-    status: isSubscribed ? 'subscribed' : 'unsubscribed',
+    status: isSubscribed ? Status.SUBSCRIBED : Status.UNSUBSCRIBED,
   }
 
   await xataClient.db.subscribers.update(id, subscriber)

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -10,6 +10,11 @@ export enum Category {
   'OFFICE EQUIPMENT' = 'Office Equipment',
 }
 
+export enum Status {
+  SUBSCRIBED = 'subscribed',
+  UNSUBSCRIBED = 'unsubscribed',
+}
+
 export const FORM_DEAL_SCHEMA = z.object({
   name: z.string().max(40),
   link: z.string().url(),


### PR DESCRIPTION
closes #16 

## Describe Changes:
Added Status enum:

```ts
export enum Status {
  SUBSCRIBED = 'subscribed',
  UNSUBSCRIBED = 'unsubscribed',
}
```

implemented in the following files:

- Types.ts
- Subscriber.tsx
- queries.ts