### PR TITLE
Make md and lg views of hero responsive

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
         <PHProvider>
           <body className="">
             <div className="flex min-h-screen flex-col justify-between bg-gray-900">
-              <div className="mx-auto w-full max-w-screen-3xl pt-5 md:px-24 xl:pt-20">
+              <div className="mx-auto w-full max-w-screen-2xl pt-5 md:px-24 xl:pt-20">
                 <SearchProvider>
                   <GlobalSearch />
                   <Nav />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
         <PHProvider>
           <body className="">
             <div className="flex min-h-screen flex-col justify-between bg-gray-900">
-              <div className="mx-auto w-full max-w-[1728px] pt-5 md:px-24 xl:pt-[84px]">
+              <div className="mx-auto w-full max-w-screen-3xl pt-5 md:px-24 xl:pt-20">
                 <SearchProvider>
                   <GlobalSearch />
                   <Nav />

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -45,7 +45,7 @@ export default function RootLayout({
         <PHProvider>
           <body className="">
             <div className="flex min-h-screen flex-col justify-between bg-gray-900">
-              <div className="mx-auto w-full max-w-[1728px] pt-5 md:px-24 md:pt-[84px]">
+              <div className="mx-auto w-full max-w-[1728px] pt-5 md:px-24 xl:pt-[84px]">
                 <SearchProvider>
                   <GlobalSearch />
                   <Nav />

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,14 +4,14 @@ export default function Hero() {
   return (
     <div className="px-6 md:px-0">
       <div className="flex flex-col gap-6 md:gap-12 md:pb-32 lg:gap-16 xl:flex-row">
-        <h1 className="max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-[650px] md:text-6xl md:leading-[67px] lg:text-7xl xl:max-w-[861px]">
+        <h1 className="md:leading-16 xl:max-w-3xl-plus max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-2xl md:text-6xl lg:text-7xl">
           The best <span className="text-teal-500">deals</span> and{' '}
           <span className="text-teal-500">giveaways</span> for developers
         </h1>
 
         {/* subscription form */}
         <div>
-          <p className="mb-3 text-sm leading-5 text-white md:mb-6 md:max-w-[550px] md:text-xl md:leading-8 lg:text-2xl">
+          <p className="mb-3 text-sm leading-5 text-white md:mb-6 md:max-w-lg md:text-xl md:leading-8 lg:max-w-xl lg:text-2xl">
             Get upcoming and ongoing deals sent straight to your inbox every
             month!
           </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,15 +3,15 @@ import SubscribeForm from './forms/SubscribeForm'
 export default function Hero() {
   return (
     <div className="px-6 md:px-0">
-      <div className="flex flex-col gap-6 md:flex-row md:gap-24 ">
-        <h1 className="max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-[861px] md:text-7xl md:leading-[84px]">
+      <div className="flex flex-col gap-6 md:gap-12 md:pb-32 lg:gap-16 xl:flex-row">
+        <h1 className="max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-[650px] md:text-6xl md:leading-[67px] lg:text-7xl xl:max-w-[861px]">
           The best <span className="text-teal-500">deals</span> and{' '}
           <span className="text-teal-500">giveaways</span> for developers
         </h1>
 
         {/* subscription form */}
         <div>
-          <p className="mb-3 text-sm leading-5 text-white md:mb-6 md:text-2xl md:leading-8">
+          <p className="mb-3 text-sm leading-5 text-white md:mb-6 md:max-w-[550px] md:text-xl md:leading-8 lg:text-2xl">
             Get upcoming and ongoing deals sent straight to your inbox every
             month!
           </p>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,7 +4,7 @@ export default function Hero() {
   return (
     <div className="px-6 md:px-0">
       <div className="flex flex-col gap-6 md:gap-12 md:pb-32 lg:gap-16 xl:flex-row">
-        <h1 className="md:leading-16 xl:max-w-3xl-plus max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-2xl md:text-6xl lg:text-7xl">
+        <h1 className="md:leading-14 lg:leading-16 max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-2xl md:text-6xl lg:text-7xl xl:max-w-3xl">
           The best <span className="text-teal-500">deals</span> and{' '}
           <span className="text-teal-500">giveaways</span> for developers
         </h1>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -3,19 +3,21 @@ import SubscribeForm from './forms/SubscribeForm'
 export default function Hero() {
   return (
     <div className="px-6 md:px-0">
-      <div className="flex flex-col gap-6 md:gap-12 md:pb-32 lg:gap-16 xl:flex-row">
-        <h1 className="md:leading-14 lg:leading-16 max-w-80 text-4xl font-semibold leading-10 tracking-tight text-white md:max-w-2xl md:text-6xl lg:text-7xl xl:max-w-3xl">
+      <div className="flex justify-center pl-2 md:pl-12 lg:pl-14">
+        <div className="flex flex-col gap-6 md:gap-12 md:pb-32 lg:gap-16 xl:flex-row">
+        <h1 className="max-w-80 md:leading-14 lg:leading-16 text-4xl font-semibold leading-10 tracking-tight text-white lg:max-w-2xl md:max-w-xl md:text-6xl lg:text-7xl xl:max-w-3xl">
           The best <span className="text-teal-500">deals</span> and{' '}
           <span className="text-teal-500">giveaways</span> for developers
         </h1>
 
         {/* subscription form */}
         <div>
-          <p className="mb-3 text-sm leading-5 text-white md:mb-6 md:max-w-lg md:text-xl md:leading-8 lg:max-w-xl lg:text-2xl">
+          <p className="mb-3 text-sm max-w-80 leading-5 text-white md:mb-6 md:max-w-lg md:text-xl md:leading-8 lg:max-w-xl lg:text-2xl">
             Get upcoming and ongoing deals sent straight to your inbox every
             month!
           </p>
           <SubscribeForm />
+          </div>
         </div>
       </div>
     </div>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,6 +28,13 @@ const config = {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
+      lineHeight: {
+        '16': '4.2rem',
+      },
+      maxWidth: {
+        '3xl-plus': '860px',
+        'screen-3xl': '1728px',
+      }
     },
   },
   plugins: [require('tailwindcss-animate')],

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -29,12 +29,9 @@ const config = {
         'accordion-up': 'accordion-up 0.2s ease-out',
       },
       lineHeight: {
-        '16': '4.2rem',
+        '14': '4rem',
+        '16': '5.2rem',
       },
-      maxWidth: {
-        '3xl-plus': '860px',
-        'screen-3xl': '1728px',
-      }
     },
   },
   plugins: [require('tailwindcss-animate')],


### PR DESCRIPTION
This fixes issue #10 

Sorry for the delay, I've been sick for a few days now 😢. 

I ended up editing the layout for md and lg, here's how it looks on my computer:

md:
![md-deals](https://github.com/Learn-Build-Teach/deals-for-devs/assets/112726692/cad51fc7-499f-48fe-b83a-e31b651c9ed5)

lg:
![lg-deals](https://github.com/Learn-Build-Teach/deals-for-devs/assets/112726692/c656b82a-0fa2-4378-b52f-dc5a21cfc09a)

Please let me know if that looks ok to you or if I should change anything else, I also noticed on the smallest view the <p> text seems a bit long since it is much wider than the email input, so if you want me to I could add a max width? 
![sm-deals](https://github.com/Learn-Build-Teach/deals-for-devs/assets/112726692/6472a365-c610-4038-95fc-a3e5587dcc72)
