### PR TITLE
feat: add aria-label to input

### DIFF
--- a/src/app/deals/add/DealForm.tsx
+++ b/src/app/deals/add/DealForm.tsx
@@ -316,6 +316,7 @@ export default function DealForm() {
               id="email"
               type="text"
               required
+              aria-label="email"
             />
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,18 +14,21 @@ const techStack: TechStack[] = [
     Url: 'https://nextjs.org/',
     id: 'nextjs',
     size: 173.58,
+    alt: 'Next.js',
     className: 'w-20 h-3.5 md:w-44 md:h-7',
   },
   {
     Url: 'https://xata.io/',
     id: 'xata',
     size: 142,
+    alt: 'Xata',
     className: 'w-20 h-9 md:w-36 md:h-10',
   },
   {
     Url: 'https://sentry.io/',
     id: 'sentry',
     size: 221,
+    alt: 'Sentry',
     className: 'w-28 h-8 md:w-56 md:h-16',
   },
 ]

--- a/src/components/nav/Nav.tsx
+++ b/src/components/nav/Nav.tsx
@@ -20,7 +20,7 @@ export default function Nav() {
         className={cn(
           'mb-[79px] flex w-full items-center px-6 md:mb-[153px] md:px-0'
         )}
-        aria-label="Global"
+        aria-label="main navigation"
       >
         {/* D4D logo */}
         {/* <Link href="/">


### PR DESCRIPTION
## Description
This PR makes the code more a11y-friendly, making it easier for developers who use screen readers to navigate the website. 

## Related Tickets and Documents

Closes #62 

## Screenshots 

### Result for fixing input
![pass for aria-label email](https://github.com/Learn-Build-Teach/deals-for-devs/assets/105683440/04354d44-d513-4cc2-a030-89653743871f)


### Result for improving nav's aria-label
![passing of 2nd accessibility test](https://github.com/Learn-Build-Teach/deals-for-devs/assets/105683440/92d28813-4fd9-4f5d-9de3-fcaf887e73ef)

### Add alt to footer icons (Sentry and Xata)
![logos-passed-test](https://github.com/Learn-Build-Teach/deals-for-devs/assets/105683440/fc5be4fb-bff8-4053-8bf0-f9e9e7f1db85)

