### PR TITLE
feat: Add Default Image for Deals

### DIFF
--- a/src/app/(deals)/deals/[category]/page.tsx
+++ b/src/app/(deals)/deals/[category]/page.tsx
@@ -3,30 +3,31 @@ import { redirect } from 'next/navigation'
 import { Category } from '@/types/Types'
 import { getApprovedDealsByCategory } from '@/lib/queries'
 import PageHeader from '@/components/PageHeader'
+import DealsList from '@/components/deals/DealsList'
 
 export default async function CategoryPage({
   params,
 }: {
   params: { category: string }
 }) {
-  const { category: categoryString } = params
-  console.log(categoryString)
-  //check for valid category
-  if (
-    !categoryString ||
-    Object.keys(Category).indexOf(categoryString.toUpperCase()) === -1
-  ) {
+  if (!params.category) {
+    redirect('/')
+  }
+
+  const categoryString = decodeURIComponent(params.category).toUpperCase()
+
+  if (Object.keys(Category).indexOf(categoryString as Category) === -1) {
     redirect('/')
   }
   const category = categoryString as Category
-
+  console.log(category)
   const deals = await getApprovedDealsByCategory(category)
   console.log(deals)
   return (
     <div>
       <div className="pb-10">
         <PageHeader
-          title={category}
+          title={category.toLocaleLowerCase()}
           subtitle={`The best ${category.toLowerCase()} deals`}
         />
       </div>
@@ -38,7 +39,7 @@ export default async function CategoryPage({
           No deals found for this category
         </div>
       )}
-      {/* <DealsList deals={deals} /> */}
+      <DealsList deals={deals} />
     </div>
   )
 }

--- a/src/app/(deals)/deals/[category]/page.tsx
+++ b/src/app/(deals)/deals/[category]/page.tsx
@@ -20,9 +20,8 @@ export default async function CategoryPage({
     redirect('/')
   }
   const category = categoryString as Category
-  console.log(category)
   const deals = await getApprovedDealsByCategory(category)
-  console.log(deals)
+
   return (
     <div>
       <div className="pb-10">

--- a/src/app/(deals)/deals/[category]/page.tsx
+++ b/src/app/(deals)/deals/[category]/page.tsx
@@ -1,6 +1,8 @@
 import CategoryOptions from '@/components/CategoryOptions'
 import { redirect } from 'next/navigation'
 import { Category } from '@/types/Types'
+import { getApprovedDealsByCategory } from '@/lib/queries'
+import PageHeader from '@/components/PageHeader'
 
 export default async function CategoryPage({
   params,
@@ -8,20 +10,34 @@ export default async function CategoryPage({
   params: { category: string }
 }) {
   const { category: categoryString } = params
+  console.log(categoryString)
   //check for valid category
-  if (!(categoryString in Category)) {
+  if (
+    !categoryString ||
+    Object.keys(Category).indexOf(categoryString.toUpperCase()) === -1
+  ) {
     redirect('/')
   }
-  //   const category = categoryString as Category;
+  const category = categoryString as Category
 
-  //   const deals = await getApprovedDealsByCategory(category);
-  redirect('/')
+  const deals = await getApprovedDealsByCategory(category)
+  console.log(deals)
   return (
     <div>
-      <h1 className="mb-10 text-center text-4xl font-bold text-white">
-        Top <span className="text-teal-500">{params.category}</span> Deals
-      </h1>
-      <CategoryOptions />
+      <div className="pb-10">
+        <PageHeader
+          title={category}
+          subtitle={`The best ${category.toLowerCase()} deals`}
+        />
+      </div>
+      <div className="pb-10">
+        <CategoryOptions />
+      </div>
+      {deals.length === 0 && (
+        <div className="text-center text-lg text-gray-500">
+          No deals found for this category
+        </div>
+      )}
       {/* <DealsList deals={deals} /> */}
     </div>
   )

--- a/src/components/CategoryOption.tsx
+++ b/src/components/CategoryOption.tsx
@@ -1,10 +1,16 @@
 import Link from 'next/link'
 import React from 'react'
 
-export default function CategoryOption({ category }: { category: string }) {
+export default function CategoryOption({
+  category,
+  path,
+}: {
+  category: string
+  path?: string
+}) {
   return (
     <Link
-      href={`/deals/${category}`}
+      href={path || `/deals/${category}`}
       className="rounded-full border border-white px-4 py-2 text-white"
     >
       {category}

--- a/src/components/CategoryOptions.tsx
+++ b/src/components/CategoryOptions.tsx
@@ -5,7 +5,7 @@ export default function CategoryOptions() {
   return (
     <div>
       <div className="flex flex-wrap items-center gap-4">
-        <CategoryOption category="all" />
+        <CategoryOption category="all" path="/deals" />
         {Object.values(Category).map((category) => (
           <CategoryOption category={category} key={category} />
         ))}

--- a/src/components/DealGradientPlaceholder.tsx
+++ b/src/components/DealGradientPlaceholder.tsx
@@ -1,0 +1,59 @@
+import { Category } from '@/types/Types'
+import React from 'react'
+import {
+  FaBeer,
+  FaBook,
+  FaCalendar,
+  FaChair,
+  FaCog,
+  FaCompactDisc,
+  FaDeskpro,
+  FaDesktop,
+  FaMicrophone,
+  FaSchool,
+  FaTable,
+  FaTag,
+  FaVideo,
+} from 'react-icons/fa'
+import { twMerge } from 'tailwind-merge'
+
+interface DealGradientPlaceholderProps {
+  category: Category
+}
+
+//TODO: how to use enum keys/values instead of hard-coded values?
+const categoryToGradient: { [key: string]: string } = {
+  MISC: 'from-indigo-100  to-indigo-300',
+  EBOOKS: 'from-lime-100  to-lime-300',
+  COURSES: 'from-amber-100  to-amber-300',
+  TOOLS: 'from-red-100  to-red-300',
+  CONFERENCES: 'from-pink-100  to-pink-300',
+  BOOTCAMPS: 'from-orange-100  to-orange-300',
+  'OFFICE EQUIPMENT': 'from-teal-100  to-teal-300',
+}
+const categoryToIcon: { [key: string]: JSX.Element } = {
+  MISC: <FaTag className="h-16 w-16" />,
+  EBOOKS: <FaBook className="h-16 w-16" />,
+  COURSES: <FaDesktop className="h-16 w-16" />,
+  TOOLS: <FaCog className="h-16 w-16" />,
+  CONFERENCES: <FaMicrophone className="h-16 w-16" />,
+  BOOTCAMPS: <FaSchool className="h-16 w-16" />,
+  'OFFICE EQUIPMENT': <FaChair className="h-16 w-16" />,
+}
+
+export default function DealGradientPlaceholder({
+  category,
+}: DealGradientPlaceholderProps) {
+  return (
+    <div
+      className={twMerge(
+        'flex aspect-video w-full items-center justify-center rounded-2xl bg-gradient-to-r group-hover:outline group-hover:outline-teal-500',
+        categoryToGradient[category || 'MISC']
+      )}
+    >
+      <div className="h-16 w-16 text-gray-900">
+        {categoryToIcon[category || 'MISC']}
+      </div>
+    </div>
+  )
+}

--- a/src/components/deals/DealCard.tsx
+++ b/src/components/deals/DealCard.tsx
@@ -6,6 +6,7 @@ import { Category } from '@/types/Types'
 import { format } from 'date-fns'
 import { Deal } from '@prisma/client'
 import Image from 'next/image'
+import DealGradientPlaceholder from '../DealGradientPlaceholder'
 
 const categoryToIcon: { [key: string]: JSX.Element } = {
   Misc: <FaBeer />,
@@ -36,17 +37,22 @@ export default function DealCard({
   return (
     <Link
       href={deal.link}
-      className="group relative text-white hover:text-teal-500"
+      className="group relative w-full text-white hover:text-teal-500"
       target="_blank"
       rel="noopener noreferrer"
     >
-      <Image
-        src={deal.coverImageURL}
-        alt={deal.name}
-        width={480}
-        height={270}
-        className="mb-3 aspect-video rounded-2xl transition duration-300 ease-in-out group-hover:outline group-hover:outline-teal-500"
-      />
+      {!deal.coverImageURL && (
+        <DealGradientPlaceholder category={deal.category as Category} />
+      )}
+      {deal.coverImageURL && (
+        <Image
+          src={deal.coverImageURL}
+          alt={deal.name}
+          width={480}
+          height={270}
+          className="aspect-video rounded-2xl transition duration-300 ease-in-out group-hover:outline group-hover:outline-teal-500"
+        />
+      )}
       <h2 className="text-lg font-semibold tracking-tight">{deal.name}</h2>
       {deal.coupon && deal.couponPercent && (
         <p className="-gap-y-1 bg-pale-gold absolute right-3 top-3 flex h-14 w-14 -rotate-12 flex-col items-center justify-center rounded-full  text-black shadow-md">

--- a/src/components/forms/add-a-deal/CategorySelect.tsx
+++ b/src/components/forms/add-a-deal/CategorySelect.tsx
@@ -31,7 +31,7 @@ export default function CategorySelect({
             .map((dealType) => (
               <SelectItem
                 key={dealType}
-                value={dealType}
+                value={dealType.toUpperCase()}
                 className="text-base md:text-xl"
               >
                 {dealType}

--- a/src/components/forms/add-a-deal/ReviewDeal.tsx
+++ b/src/components/forms/add-a-deal/ReviewDeal.tsx
@@ -6,6 +6,8 @@ import toast from 'react-hot-toast'
 import z from 'zod'
 import { createDeal } from '@/lib/queries'
 import Image from 'next/image'
+import DealGradientPlaceholder from '@/components/DealGradientPlaceholder'
+import { Category } from '@/types/Types'
 
 export default function ReviewDeal() {
   const { newDealData } = useAddDealContext()
@@ -66,13 +68,20 @@ export default function ReviewDeal() {
           {/* display image & percent badge */}
           <div className="relative">
             <div className="relative aspect-video w-full overflow-hidden lg:w-60">
-              <Image
-                src={coverImage}
-                alt={newDealData.productName}
-                className=" rounded-lg"
-                fill={true}
-                priority
-              />
+              {!newDealData.coverImageURL && (
+                <DealGradientPlaceholder
+                  category={newDealData.category as Category}
+                />
+              )}
+              {newDealData.coverImageURL && (
+                <Image
+                  src={coverImage}
+                  alt={newDealData.productName}
+                  className=" rounded-lg"
+                  fill={true}
+                  priority
+                />
+              )}
             </div>
             {/* display the percent off badge if indicated */}
             {newDealData?.percentage && (

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -115,7 +115,7 @@ export async function getApprovedDealsByCategory(
   return await prisma.deal.findMany({
     where: {
       approved: true,
-      category,
+      category: category.toUpperCase(),
     },
   })
 }

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod'
 
 export enum Category {
-  EBOOK = 'Ebook',
-  COURSE = 'Course',
-  TOOL = 'Tool',
-  CONFERENCE = 'Conference',
+  EBOOKS = 'Ebooks',
+  COURSES = 'Courses',
+  TOOLS = 'Tools',
+  CONFERENCES = 'Conferences',
   MISC = 'Misc',
-  BOOTCAMP = 'Bootcamp',
+  BOOTCAMPS = 'Bootcamps',
   'OFFICE EQUIPMENT' = 'Office Equipment',
 }
 


### PR DESCRIPTION
## Description
This adds default "images" for deals that display a gradient based on the category type along with an icon.

## Issue
Closes #130 

## Screenshot
![CleanShot 2024-05-16 at 15 56 41](https://github.com/Learn-Build-Teach/deals-for-devs/assets/5391915/09bcfd6c-22e6-44b2-b443-0e051a040521)


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


