### PR TITLE
fix: handle error for too large file upload

### DIFF
--- a/src/components/forms/add-a-deal/DragAndDropImage.tsx
+++ b/src/components/forms/add-a-deal/DragAndDropImage.tsx
@@ -1,25 +1,42 @@
 import React, { useCallback, useState } from 'react'
-import { useDropzone } from 'react-dropzone'
+import { DropEvent, FileRejection, useDropzone } from 'react-dropzone'
 import Icon from '@/components/Icon'
+import toast from 'react-hot-toast'
 
 export default function DragAndDropImage({
   onFileChange,
 }: {
-  onFileChange: (file: any) => void
+  onFileChange: (file: File) => void
   handleDelete: () => void
 }) {
   const [file, setFile] = useState<File | undefined>()
 
   const onDrop = useCallback(
-    (acceptedFile: File[]) => {
-      setFile(acceptedFile[0])
-      onFileChange(acceptedFile[0])
+    (acceptedFiles: File[]) => {
+      console.log(acceptedFiles)
+      if (acceptedFiles.length === 0) return
+
+      setFile(acceptedFiles[0])
+      onFileChange(acceptedFiles[0])
     },
     [onFileChange]
   )
 
+  const onDropRejected = useCallback(
+    (fileRejections: FileRejection[], event: DropEvent) => {
+      console.log(fileRejections)
+      const fileRejection = fileRejections[0]
+      const fileError = fileRejection.errors[0]
+      if (fileError.code === 'file-too-large') {
+        toast.error('File is too large. Max file size is 2MB')
+      }
+    },
+    []
+  )
+
   const { getRootProps, getInputProps } = useDropzone({
     onDrop,
+    onDropRejected,
     accept: {
       'image/png': ['.png'],
       'image/jpeg': ['.jpg', '.jpeg'],
@@ -43,7 +60,7 @@ export default function DragAndDropImage({
           Drag ‘n’ drop or click to upload an image
         </p>
         <p className="text-sm font-extralight text-white md:text-lg">
-          PNG, JPEG files accepted
+          Formats: PNG, JPEG (2mb max)
         </p>
       </div>
     </div>

--- a/src/components/forms/add-a-deal/ProductInfo.tsx
+++ b/src/components/forms/add-a-deal/ProductInfo.tsx
@@ -33,7 +33,7 @@ export default function ProductInfo() {
     router.push(`/deals/add/${AddDealRoutes.COUPON_DETAILS}`)
   }
 
-  const handleImageUpload = async (file: any) => {
+  const handleImageUpload = async (file: File) => {
     setImageUploadStatus(ImageUploadStatus.UPLOADING)
 
     // get the image upload url from xata


### PR DESCRIPTION
## Description
Show error message and handle error when uploading an image that is too big


## Screenshot
![CleanShot 2024-06-07 at 11 36 04](https://github.com/Learn-Build-Teach/deals-for-devs/assets/5391915/94e80ca5-0683-4e47-941c-3899a68a644a)


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x ] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ x] The `Description` gives a good representation of the changes made
- [ x] If this PR addresses an open Issue, it is linked in the `Issue` section


