### PR TITLE
Fix: Remove ID From Subscriber

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -38,7 +38,6 @@ model AdminUser {
 }
 
 model Subscriber {
-  id                           String   @id @default(uuid())
   status                       String
   email                        String   @db.VarChar(255)
   verified                     Boolean  @default(false)


### PR DESCRIPTION
Removing unnecessary id property on subscriber table since xata_id exists