### PR TITLE
fix: update prisma schema for coupon percent to not have a default

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,7 +12,7 @@ model Deal {
   coupon         String?    @db.VarChar(255)
   approved       Boolean    @default(false)
   description    String     @db.Text
-  couponPercent  Int?       @default(0)
+  couponPercent  Int?       
   featured       Boolean    @default(false)
   name           String     @db.VarChar(255)
   link           String     @db.VarChar(255)


### PR DESCRIPTION
## Description
Remove default of 0 for coupon percent. Should be null

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x ] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ x] The `Description` gives a good representation of the changes made
- [ x] If this PR addresses an open Issue, it is linked in the `Issue` section


