### PR TITLE
feat: add 16 x 9 image ratio requirement to form

### DIFF
--- a/src/components/forms/add-a-deal/DragAndDropImage.tsx
+++ b/src/components/forms/add-a-deal/DragAndDropImage.tsx
@@ -9,13 +9,19 @@ export default function DragAndDropImage({
   onFileChange: (file: File) => void
   handleDelete: () => void
 }) {
-  const [file, setFile] = useState<File | undefined>()
-
   const onDrop = useCallback(
-    (acceptedFiles: File[]) => {
+    async (acceptedFiles: File[]) => {
       if (acceptedFiles.length === 0) return
-      setFile(acceptedFiles[0])
-      onFileChange(acceptedFiles[0])
+      const file = acceptedFiles[0]
+
+      //* custom validation for aspect ratio
+      const img = await loadImage(file)
+      const aspectRatio = img.width / img.height
+      if (aspectRatio !== 16 / 9) {
+        return toast.error('Image should be in 16:9 aspect ratio')
+      }
+      //validation passed
+      onFileChange(file)
     },
     [onFileChange]
   )
@@ -42,6 +48,15 @@ export default function DragAndDropImage({
     multiple: false,
   })
 
+  const loadImage = (file: File): Promise<HTMLImageElement> => {
+    return new Promise((resolve, reject) => {
+      const img = new Image()
+      img.src = URL.createObjectURL(file)
+      img.onload = () => resolve(img)
+      img.onerror = () => reject(new Error('Failed to load image'))
+    })
+  }
+
   return (
     <div className="">
       <div
@@ -58,6 +73,9 @@ export default function DragAndDropImage({
         </p>
         <p className="text-sm font-extralight text-white md:text-lg">
           Formats: PNG, JPEG (2mb max)
+        </p>
+        <p className="text-sm font-extralight text-white md:text-lg">
+          Image Ratio: 16:9
         </p>
       </div>
     </div>

--- a/src/components/forms/add-a-deal/ProductInfo.tsx
+++ b/src/components/forms/add-a-deal/ProductInfo.tsx
@@ -157,8 +157,8 @@ export default function ProductInfo() {
                   <Image
                     src={newDealData.coverImageURL}
                     alt="Product Image"
-                    width={700}
-                    height={400}
+                    width={1280}
+                    height={720}
                     className="absolute bottom-0 left-0 right-0 top-0 aspect-video w-full object-cover"
                   />
                   <button


### PR DESCRIPTION
## Description
Add a requirement of 16 by 9 for deal images to keep a consistent aspect ratio

## Issue
Closes #175 

## Screenshot
https://github.com/Learn-Build-Teach/deals-for-devs/assets/5391915/b4e0ef39-2869-4f0e-9091-759b2bc71a5f


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [ x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ x] The `Description` gives a good representation of the changes made
- [ x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->