### PR TITLE
PERF: Improve Time to First Byte For Deals Pages

### DIFF
--- a/src/app/deals/[id]/loading.tsx
+++ b/src/app/deals/[id]/loading.tsx
@@ -1,0 +1,6 @@
+import LoadingPreview from '@/components/deals/loading/LoadingPreview'
+import React from 'react'
+
+export default function Loading() {
+  return <LoadingPreview />
+}

--- a/src/app/deals/[id]/page.tsx
+++ b/src/app/deals/[id]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation'
 import { getApprovedDeals, getDealById } from '@/lib/queries'
-import DealPreview from '@/components/DealPreview'
-import { Metadata, ResolvingMetadata } from 'next'
+import { Metadata } from 'next'
+import DealPreview from '@/components/deals/DealPreview'
 
 export const revalidate = 120
 
@@ -19,14 +19,7 @@ export async function generateStaticParams() {
   }))
 }
 
-export async function generateMetadata(
-  { params }: Props,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  // read route params
-  const id = params.id
-
-  // fetch data
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
   const deal = await getDealById(params.id)
 
   if (!deal) {
@@ -44,10 +37,15 @@ export async function generateMetadata(
   }
 }
 
+//sleep function
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
 export default async function DealPage({ params }: { params: { id: string } }) {
   if (!params.id) {
-    //not found
+    notFound()
   }
+
   const deal = await getDealById(params.id)
   if (!deal) {
     notFound()

--- a/src/app/deals/category/[category]/page.tsx
+++ b/src/app/deals/category/[category]/page.tsx
@@ -4,6 +4,9 @@ import { Category } from '@/types/Types'
 import { getApprovedDealsByCategory } from '@/lib/queries'
 import PageHeader from '@/components/PageHeader'
 import DealsList from '@/components/deals/DealsList'
+import ApprovedDealsByCategory from '@/components/deals/ApprovedDealsByCategory'
+import { Suspense } from 'react'
+import LoadingDealsList from '@/components/deals/loading/LoadingDealsList'
 
 export const revalidate = 120
 
@@ -23,7 +26,6 @@ export default async function CategoryPage({
   }
   //TODO move logic for converting deals to capitalized and singular to a helper function
   const category = categoryString as Category
-  const deals = await getApprovedDealsByCategory(category)
   let capitalizedCategory = category
     .split(' ')
     .map((word) => word.charAt(0).toUpperCase() + word.toLowerCase().slice(1))
@@ -39,12 +41,9 @@ export default async function CategoryPage({
       <div className="pb-10">
         <CategoryOptions />
       </div>
-      {deals.length === 0 && (
-        <div className="text-center text-xl text-gray-300">
-          No deals found for this category
-        </div>
-      )}
-      <DealsList deals={deals} />
+      <Suspense fallback={<LoadingDealsList count={3} />}>
+        <ApprovedDealsByCategory category={category} />
+      </Suspense>
     </main>
   )
 }

--- a/src/app/deals/page.tsx
+++ b/src/app/deals/page.tsx
@@ -1,13 +1,13 @@
 import CategoryOptions from '@/components/CategoryOptions'
-import { getApprovedDeals } from '@/lib/queries'
 import NeverMissADeal from '@/components/NeverMissADeal'
 import PageHeader from '@/components/PageHeader'
-import DealsList from '@/components/deals/DealsList'
+import ApprovedDeals from '@/components/deals/ApprovedDeals'
+import LoadingDealsList from '@/components/deals/loading/LoadingDealsList'
+import { Suspense } from 'react'
 
 export const revalidate = 120
 
 export default async function DealsPage() {
-  const deals = await getApprovedDeals(20)
   //TODO: handle error
   return (
     <main>
@@ -17,12 +17,9 @@ export default async function DealsPage() {
       <div className="pb-10">
         <CategoryOptions />
       </div>
-      {deals.length === 0 && (
-        <div className="text-center text-xl text-gray-300">
-          No deals found for this category
-        </div>
-      )}
-      <DealsList deals={deals} />
+      <Suspense fallback={<LoadingDealsList count={3} />}>
+        <ApprovedDeals />
+      </Suspense>
       <NeverMissADeal />
     </main>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,16 @@
+import FeaturedDealsSection from '@/components/deals/FeaturedDealsSection'
 import DevGiveaways from '@/components/DevGiveaways'
-import FeaturedDeals from '@/components/FeaturedDeals'
 import Hero from '@/components/Hero'
 import NeverMissADeal from '@/components/NeverMissADeal'
 import Separator from '@/components/Separator'
-import { getApprovedFeaturedDeals } from '@/lib/queries'
 
 export const revalidate = 120
 
 export default async function Home() {
-  const deals = await getApprovedFeaturedDeals()
   return (
     <main>
       <Hero />
-
-      <FeaturedDeals deals={deals} />
+      <FeaturedDealsSection />
       <Separator className="mb-20" />
       <div className="mb-20">
         <NeverMissADeal />

--- a/src/components/IconButton.tsx
+++ b/src/components/IconButton.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default function IconButton({
+  handleClick,
+  children,
+}: {
+  handleClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      className="text-brand bg-surface-1  hover:bg-surface-2 flex h-10 w-10 items-center justify-center rounded-full text-xs transition-transform hover:-translate-y-0.5"
+      onClick={handleClick}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/components/deals/ApprovedDeals.tsx
+++ b/src/components/deals/ApprovedDeals.tsx
@@ -1,0 +1,9 @@
+import { getApprovedDeals } from '@/lib/queries'
+import React from 'react'
+import DealsList from './DealsList'
+
+export default async function ApprovedDeals() {
+  const deals = await getApprovedDeals(20)
+
+  return <DealsList deals={deals} />
+}

--- a/src/components/deals/ApprovedDealsByCategory.tsx
+++ b/src/components/deals/ApprovedDealsByCategory.tsx
@@ -1,0 +1,14 @@
+import { getApprovedDealsByCategory } from '@/lib/queries'
+import React from 'react'
+import DealsList from './DealsList'
+import { Category } from '@/types/Types'
+
+export default async function ApprovedDealsByCategory({
+  category,
+}: {
+  category: Category
+}) {
+  const deals = await getApprovedDealsByCategory(category)
+
+  return <DealsList deals={deals} />
+}

--- a/src/components/deals/DealCard.tsx
+++ b/src/components/deals/DealCard.tsx
@@ -1,16 +1,7 @@
 import Link from 'next/link'
-import { FaBeer, FaVideo, FaBook, FaCog, FaCalendar } from 'react-icons/fa'
 import { Category } from '@/types/Types'
 import { Deal } from '@prisma/client'
 import DealImage from './DealImage'
-
-const categoryToIcon: { [key: string]: JSX.Element } = {
-  Misc: <FaBeer />,
-  Ebook: <FaBook />,
-  Video: <FaVideo />,
-  Tool: <FaCog />,
-  Conference: <FaCalendar />,
-}
 
 export default function DealCard({ deal }: { deal: Deal }) {
   return (
@@ -24,7 +15,7 @@ export default function DealCard({ deal }: { deal: Deal }) {
         coverImageURL={deal.coverImageURL}
         category={deal.category as Category}
       />
-      <h2 className="text-lg font-semibold tracking-tight">{deal.name}</h2>
+      <h2 className="mt-1 text-lg font-semibold tracking-tight">{deal.name}</h2>
       {deal.coupon && deal.couponPercent && (
         <p className="-gap-y-1 absolute right-3 top-3 flex h-14 w-14 -rotate-12 flex-col items-center justify-center rounded-full bg-pale-gold  text-black shadow-md">
           <span className="text-md -mb-1 font-bold">{deal.couponPercent}%</span>

--- a/src/components/deals/DealGradientPlaceholder.tsx
+++ b/src/components/deals/DealGradientPlaceholder.tsx
@@ -1,19 +1,13 @@
 import { Category } from '@/types/Types'
 import React from 'react'
 import {
-  FaBeer,
   FaBook,
-  FaCalendar,
   FaChair,
   FaCog,
-  FaCompactDisc,
-  FaDeskpro,
   FaDesktop,
   FaMicrophone,
   FaSchool,
-  FaTable,
   FaTag,
-  FaVideo,
 } from 'react-icons/fa'
 import { twMerge } from 'tailwind-merge'
 

--- a/src/components/deals/DealImage.tsx
+++ b/src/components/deals/DealImage.tsx
@@ -1,7 +1,7 @@
 import { Category } from '@/types/Types'
 import { Deal } from '@prisma/client'
 import React from 'react'
-import DealGradientPlaceholder from '../DealGradientPlaceholder'
+import DealGradientPlaceholder from './DealGradientPlaceholder'
 import Image from 'next/image'
 
 interface IDealImageProps {

--- a/src/components/deals/DealPreview.tsx
+++ b/src/components/deals/DealPreview.tsx
@@ -1,10 +1,7 @@
 import { format } from 'date-fns'
-import React from 'react'
-import DealGradientPlaceholder from './DealGradientPlaceholder'
 import { Category } from '@/types/Types'
-import Image from 'next/image'
-import ClickableCoupon from './ClickableCouponCode'
-import DealImage from './deals/DealImage'
+import DealImage from './DealImage'
+import ClickableCoupon from '../ClickableCouponCode'
 
 export default function DealPreview({
   link,
@@ -35,8 +32,8 @@ export default function DealPreview({
           category={category as Category}
         />
       </div>
-      <div className="flex  flex-col gap-y-1">
-        <span className="text-xl md:text-3xl">{name}</span>
+      <div className="flex flex-col gap-y-1">
+        <h1 className="text-xl md:text-3xl">{name}</h1>
         <div className="mt-2 flex flex-wrap gap-2 text-sm md:mt-4 md:text-lg">
           <span className="font-light text-white/70">Website:</span>
           <a

--- a/src/components/deals/DealsList.tsx
+++ b/src/components/deals/DealsList.tsx
@@ -10,6 +10,9 @@ export default function DealsList({
 }) {
   return (
     <div className="mx-auto py-10">
+      {deals.length === 0 && (
+        <div className="text-center text-xl text-gray-300">No deals found</div>
+      )}
       {deals.length > 0 && (
         <div className="mx-auto grid grid-cols-1 justify-items-center gap-x-4 gap-y-12 sm:grid-cols-2  lg:gap-x-12 xl:grid-cols-3">
           <>

--- a/src/components/deals/FeaturedDeals.tsx
+++ b/src/components/deals/FeaturedDeals.tsx
@@ -1,0 +1,7 @@
+import DealsList from './DealsList'
+import { getApprovedFeaturedDeals } from '@/lib/queries'
+
+export default async function FeaturedDeals() {
+  const deals = await getApprovedFeaturedDeals()
+  return <DealsList deals={deals} />
+}

--- a/src/components/deals/FeaturedDealsSection.tsx
+++ b/src/components/deals/FeaturedDealsSection.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
-import DealsList from './deals/DealsList'
 import Link from 'next/link'
-import { Deal } from '@prisma/client'
+import FeaturedDeals from './FeaturedDeals'
+import { Suspense } from 'react'
+import LoadingDealsList from './loading/LoadingDealsList'
 
-export default function FeaturedDeals({ deals }: { deals: Deal[] }) {
+export default function FeaturedDealsSection() {
   return (
     <section className="py-20">
       <div className="flex flex-col items-center gap-x-8 gap-y-4 pb-10 md:flex-row">
@@ -18,7 +18,9 @@ export default function FeaturedDeals({ deals }: { deals: Deal[] }) {
           View all deals
         </Link>
       </div>
-      <DealsList deals={deals} />
+      <Suspense fallback={<LoadingDealsList count={3} />}>
+        <FeaturedDeals />
+      </Suspense>
     </section>
   )
 }

--- a/src/components/deals/loading/LoadingDealImage.tsx
+++ b/src/components/deals/loading/LoadingDealImage.tsx
@@ -1,0 +1,5 @@
+export default function LoadingDealImage() {
+  return (
+    <div className=" flex aspect-video w-full animate-pulse items-center justify-center rounded-xl border-4 border-slate-500 bg-gray-100"></div>
+  )
+}

--- a/src/components/deals/loading/LoadingDealsList.tsx
+++ b/src/components/deals/loading/LoadingDealsList.tsx
@@ -1,0 +1,20 @@
+import LoadingDealImage from './LoadingDealImage'
+
+export default function LoadingDealsList({ count }: { count: number }) {
+  const arr = Array.from(Array(count).keys())
+
+  return (
+    <div className="mx-auto py-10">
+      <div className="mx-auto grid grid-cols-1 justify-items-center gap-x-4 gap-y-12 sm:grid-cols-2  lg:gap-x-12 xl:grid-cols-3">
+        <>
+          {arr.map((num) => (
+            <div key={num} className="w-full">
+              <LoadingDealImage />
+              <div className="mt-1 h-[1.75rem]"></div>
+            </div>
+          ))}
+        </>
+      </div>
+    </div>
+  )
+}

--- a/src/components/deals/loading/LoadingPreview.tsx
+++ b/src/components/deals/loading/LoadingPreview.tsx
@@ -1,0 +1,11 @@
+import LoadingDealImage from './LoadingDealImage'
+
+export default function LoadingPreview() {
+  return (
+    <div className="flex flex-col items-start gap-10 text-white xl:flex-row xl:items-center">
+      <div className="align-center relative aspect-video w-full max-w-[600px] self-center">
+        <LoadingDealImage />
+      </div>
+    </div>
+  )
+}

--- a/src/components/search/SearchedDeal.tsx
+++ b/src/components/search/SearchedDeal.tsx
@@ -1,6 +1,6 @@
 import { Category } from '@/types/Types'
 import { Deal } from '@prisma/client'
-import DealGradientPlaceholder from '../DealGradientPlaceholder'
+import DealGradientPlaceholder from '../deals/DealGradientPlaceholder'
 import Image from 'next/image'
 import Link from 'next/link'
 import React from 'react'


### PR DESCRIPTION
## Description
This PR adds loading states for deal pages to improve the time to first byte (TTFB)

## Issue
Performance metrics for deals pages were showing up as poor in the Sentry dashboard. This was because the time to first byte (TTFB) was slow. This was caused by not providing loading states for asynchronously loaded data.

![CleanShot 2024-07-24 at 15 50 48](https://github.com/user-attachments/assets/678ca68a-8ecc-46b3-a0af-d7c00ffb8386)

## Screenshot

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section
