### PR TITLE
Fix:  end dates before start

### DIFF
--- a/src/components/forms/DatePicker.tsx
+++ b/src/components/forms/DatePicker.tsx
@@ -14,12 +14,16 @@ import {
 interface DatePickerProps extends React.HTMLAttributes<HTMLDivElement> {
   onDateChange: (date: Date | undefined) => void
   initialDate: Date | undefined
+  disableDates?: {
+    before: Date
+  }
 }
 
 export function DatePicker({
   className,
   onDateChange,
   initialDate,
+  disableDates
 }: DatePickerProps) {
   const [date, setDate] = React.useState<Date | undefined>(initialDate)
 
@@ -47,6 +51,7 @@ export function DatePicker({
           selected={date}
           onSelect={handleOnSelect}
           initialFocus
+          disabled={disableDates}
         />
       </PopoverContent>
     </Popover>

--- a/src/components/forms/add-a-deal/CouponDetails.tsx
+++ b/src/components/forms/add-a-deal/CouponDetails.tsx
@@ -115,7 +115,8 @@ export default function CouponDetails() {
                       })
                     }
                   }}
-                  initialDate={new Date(newDealData.startDate)}
+                  initialDate={new Date()}
+                  disableDates={{before: new Date()}}
                 />
               </div>
               <input
@@ -141,6 +142,7 @@ export default function CouponDetails() {
                       new Date(newDealData.endDate)
                     : undefined
                   }
+                  disableDates={{before: new Date(newDealData.startDate)}}
                 />
               </div>
             </div>


### PR DESCRIPTION
<!-- Thank you for offering your contribution with Deals for Devs! -->

## Description
React DayPicker has a prop to disable dates based on a match. I set the passed dates of the start date picker to be disabled. As for the end date picker I have the disabled dates based on the start date.

## Issue
https://github.com/Learn-Build-Teach/deals-for-devs/issues/177

## Screenshot
https://github.com/user-attachments/assets/2f06ccf6-f56b-49ba-9531-312a041eeed6

## PR Requirements
- [ x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x ] The `Description` gives a good representation of the changes made
- [ x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->