### PR TITLE
FEAT: Managing Admin Capabilities

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,9 +39,8 @@ model Tag {
 }
 
 model AdminUser {
-  userId         String   @id @default(uuid())
   email          String  @unique
-  xata_id        String   @unique(map: "AdminUser__pgroll_new_xata_id_key") @default(dbgenerated("('rec_'::text || (xata_private.xid())::text)"))
+  xata_id        String   @id @unique(map: "AdminUser__pgroll_new_xata_id_key") @default(dbgenerated("('rec_'::text || (xata_private.xid())::text)"))
   xata_version   Int      @default(0)
   xata_createdat DateTime @default(now()) @db.Timestamptz(6)
   xata_updatedat DateTime @default(now()) @db.Timestamptz(6)

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -40,10 +40,12 @@ model Tag {
 
 model AdminUser {
   userId         String   @id @default(uuid())
+  email          String  @unique
   xata_id        String   @unique(map: "AdminUser__pgroll_new_xata_id_key") @default(dbgenerated("('rec_'::text || (xata_private.xid())::text)"))
   xata_version   Int      @default(0)
   xata_createdat DateTime @default(now()) @db.Timestamptz(6)
   xata_updatedat DateTime @default(now()) @db.Timestamptz(6)
+  isSuperAdmin   Boolean  @default(false)
 }
 
 model Subscriber {

--- a/src/actions/dashboard/adminUser.ts
+++ b/src/actions/dashboard/adminUser.ts
@@ -1,0 +1,52 @@
+'use server'
+import { newAdminUserSchema } from '@/app/(public-pages)/deals/add/schemas'
+import { createAdminUser, deleteAdminUser } from '@/queries/adminUsers'
+import { ReturnValue } from '@/types/Types'
+import { isAdminUser, isSuperAdminUser } from '@/utils/auth'
+import { auth } from '@clerk/nextjs'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+
+const MODEL_STR = 'admin user'
+export const deleteAdminUserAction = async (
+  id: string
+): Promise<ReturnValue<undefined>> => {
+  const { userId } = auth().protect()
+  const isAdmin = await isAdminUser(userId)
+  if (!isAdmin) {
+    return redirect('/')
+  }
+  try {
+    await deleteAdminUser(id)
+    revalidatePath('/dashboard/admins')
+    return { message: `Successfully deleted ${MODEL_STR}`, success: true }
+  } catch (error) {
+    console.error(error)
+    return { message: `Error deleting ${MODEL_STR}`, success: false }
+  }
+}
+
+export const createAdminUserAction = async (
+  formData: FormData
+): Promise<ReturnValue<undefined>> => {
+  const { userId } = auth().protect()
+  const isSuperAdmin = await isSuperAdminUser(userId)
+  if (!isSuperAdmin) {
+    return redirect('/')
+  }
+  try {
+    const email = formData.get('email')
+    const userId = formData.get('userId')
+
+    const res = newAdminUserSchema.safeParse({ email, userId })
+    if (!res.success) {
+      return { message: 'Invalid input', success: false }
+    }
+    await createAdminUser(res.data.email, res.data.userId)
+    revalidatePath('/dashboard/admins')
+    return { message: `Successfully created ${MODEL_STR}`, success: true }
+  } catch (error) {
+    console.error(error)
+    return { message: `Error creating ${MODEL_STR}`, success: false }
+  }
+}

--- a/src/actions/dashboard/adminUser.ts
+++ b/src/actions/dashboard/adminUser.ts
@@ -3,7 +3,7 @@ import { newAdminUserSchema } from '@/app/(public-pages)/deals/add/schemas'
 import { createAdminUser, deleteAdminUser } from '@/queries/adminUsers'
 import { ReturnValue } from '@/types/Types'
 import { isAdminUser, isSuperAdminUser } from '@/utils/auth'
-import { auth } from '@clerk/nextjs'
+import { auth, currentUser } from '@clerk/nextjs'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -11,8 +11,13 @@ const MODEL_STR = 'admin user'
 export const deleteAdminUserAction = async (
   id: string
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }
@@ -29,20 +34,24 @@ export const deleteAdminUserAction = async (
 export const createAdminUserAction = async (
   formData: FormData
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isSuperAdmin = await isSuperAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isSuperAdmin = await isSuperAdminUser(email)
   if (!isSuperAdmin) {
     return redirect('/')
   }
   try {
     const email = formData.get('email')
-    const userId = formData.get('userId')
 
-    const res = newAdminUserSchema.safeParse({ email, userId })
+    const res = newAdminUserSchema.safeParse({ email })
     if (!res.success) {
       return { message: 'Invalid input', success: false }
     }
-    await createAdminUser(res.data.email, res.data.userId)
+    await createAdminUser(res.data.email)
     revalidatePath('/dashboard/admins')
     return { message: `Successfully created ${MODEL_STR}`, success: true }
   } catch (error) {

--- a/src/actions/dashboard/subscriber.ts
+++ b/src/actions/dashboard/subscriber.ts
@@ -4,7 +4,7 @@ import { newSubscriberSchema } from '@/app/(public-pages)/deals/add/schemas'
 import { createSubscriber, deleteSubscriber } from '@/lib/queries'
 import { ReturnValue, Status } from '@/types/Types'
 import { isAdminUser } from '@/utils/auth'
-import { auth } from '@clerk/nextjs'
+import { auth, currentUser } from '@clerk/nextjs'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 import { v4 as uuidv4 } from 'uuid'
@@ -14,8 +14,14 @@ const MODEL_STR = 'subscriber'
 export const deleteSubscriberAction = async (
   id: string
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }
@@ -32,8 +38,14 @@ export const deleteSubscriberAction = async (
 export const createSubscriberAction = async (
   formData: FormData
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }

--- a/src/actions/dashboard/subscriber.ts
+++ b/src/actions/dashboard/subscriber.ts
@@ -1,0 +1,64 @@
+'use server'
+
+import { newSubscriberSchema } from '@/app/(public-pages)/deals/add/schemas'
+import { createSubscriber, deleteSubscriber } from '@/lib/queries'
+import { ReturnValue, Status } from '@/types/Types'
+import { isAdminUser } from '@/utils/auth'
+import { auth } from '@clerk/nextjs'
+import { revalidatePath } from 'next/cache'
+import { redirect } from 'next/navigation'
+import { v4 as uuidv4 } from 'uuid'
+
+const MODEL_STR = 'subscriber'
+
+export const deleteSubscriberAction = async (
+  id: string
+): Promise<ReturnValue<undefined>> => {
+  const { userId } = auth().protect()
+  const isAdmin = await isAdminUser(userId)
+  if (!isAdmin) {
+    return redirect('/')
+  }
+  try {
+    await deleteSubscriber(id)
+    revalidatePath('/dashboard/subscribers')
+    return { message: `Successfully deleted ${MODEL_STR}`, success: true }
+  } catch (error) {
+    console.error(error)
+    return { message: `Error deleting ${MODEL_STR}`, success: false }
+  }
+}
+
+export const createSubscriberAction = async (
+  formData: FormData
+): Promise<ReturnValue<undefined>> => {
+  const { userId } = auth().protect()
+  const isAdmin = await isAdminUser(userId)
+  if (!isAdmin) {
+    return redirect('/')
+  }
+  try {
+    const email = formData.get('email')
+
+    const res = newSubscriberSchema.safeParse({ email })
+    if (!res.success) {
+      return { message: 'Invalid input', success: false }
+    }
+    await createSubscriber({
+      email: res.data.email,
+      token: uuidv4(),
+      courseNotifications: true,
+      ebookNotifications: true,
+      miscNotifications: true,
+      officeEquipmentNotifications: true,
+      toolNotifications: true,
+      conferenceNotifications: true,
+      status: Status.SUBSCRIBED,
+    })
+    revalidatePath('/dashboard/subscribers')
+    return { message: `Successfully created ${MODEL_STR}`, success: true }
+  } catch (error) {
+    console.error(error)
+    return { message: `Error creating ${MODEL_STR}`, success: false }
+  }
+}

--- a/src/app/(admin)/dashboard/actions.ts
+++ b/src/app/(admin)/dashboard/actions.ts
@@ -3,7 +3,7 @@ import { updateDealSchema } from '@/app/(public-pages)/deals/add/schemas'
 import { approveDeal, deleteDeal, updateDeal } from '@/lib/queries'
 import { DealWithTags } from '@/types/Types'
 import { isAdminUser } from '@/utils/auth'
-import { auth } from '@clerk/nextjs'
+import { auth, currentUser } from '@clerk/nextjs'
 import { revalidatePath } from 'next/cache'
 import { redirect } from 'next/navigation'
 
@@ -17,8 +17,14 @@ export const updateDealAction = async (
   deal: DealWithTags,
   tags: { text: string }[]
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }
@@ -47,8 +53,14 @@ export const updateDealAction = async (
 export const approveDealAction = async (
   id: string
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }
@@ -65,8 +77,14 @@ export const approveDealAction = async (
 export const deleteDealAction = async (
   id: string
 ): Promise<ReturnValue<undefined>> => {
-  const { userId } = auth().protect()
-  const isAdmin = await isAdminUser(userId)
+  auth().protect()
+  const user = await currentUser()
+
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }

--- a/src/app/(admin)/dashboard/admins/page.tsx
+++ b/src/app/(admin)/dashboard/admins/page.tsx
@@ -1,0 +1,25 @@
+import AdminUserList from '@/components/dashboard/admin/AdminList'
+import NewAdminForm from '@/components/dashboard/admin/NewAdminForm'
+import { getAllAdminUsers } from '@/queries/adminUsers'
+
+export default async function Subscribers() {
+  const admins = await getAllAdminUsers()
+
+  return (
+    <section className="px-4 pb-10">
+      <h2 className="mb-10 text-center text-5xl text-white">Manage Admins</h2>
+      <div className="mb-10">
+        <h3 className="mb-10 pt-8 text-center text-lg uppercase">
+          Add Admin User
+        </h3>
+        <NewAdminForm />
+      </div>
+      <div className="mb-10">
+        <h3 className="mb-10 pt-8 text-center text-lg uppercase">
+          Admin Users
+        </h3>
+        <AdminUserList admins={admins} />
+      </div>
+    </section>
+  )
+}

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -23,7 +23,7 @@ export default async function Home({
       <div className="h-full w-52 md:w-80">
         <AdminNav />
       </div>
-      <main className=" ml-52 px-8 py-20 md:ml-80">{children}</main>
+      <main className=" ml-52 px-4 py-20 md:ml-80 md:px-8">{children}</main>
     </div>
   )
 }

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -1,4 +1,4 @@
-import { auth } from '@clerk/nextjs'
+import { auth, currentUser } from '@clerk/nextjs'
 import { isAdminUser } from '@/utils/auth'
 import { redirect } from 'next/navigation'
 import AdminNav from '@/components/dashboard/AdminNav'
@@ -8,12 +8,15 @@ export default async function Home({
 }: {
   children: React.ReactNode
 }) {
-  const { userId } = auth().protect()
+  auth().protect()
 
-  // If user is logged in check if user is an admin
-  const isAdmin = await isAdminUser(userId)
+  const user = await currentUser()
 
-  // If user is not an admin, redirects them to the homepage
+  const email = user?.emailAddresses[0].emailAddress
+  if (!email) {
+    return redirect('/')
+  }
+  const isAdmin = await isAdminUser(email)
   if (!isAdmin) {
     return redirect('/')
   }

--- a/src/app/(admin)/dashboard/subscribers/page.tsx
+++ b/src/app/(admin)/dashboard/subscribers/page.tsx
@@ -1,5 +1,6 @@
 import { getAllSubscribers } from '@/lib/queries'
 import SubscriberList from '@/components/subscriber/SubscriberList'
+import NewSubscriberForm from '@/components/dashboard/subscribers/NewSubscriberForm'
 
 export default async function Subscribers() {
   // fetch all subscribers
@@ -8,9 +9,20 @@ export default async function Subscribers() {
   const subscriberList = JSON.parse(JSON.stringify(subscribers))
 
   return (
-    <section className="mx-auto space-y-12 px-4 pb-10">
-      <h2 className="text-center text-5xl text-white">Manage Subscribers</h2>
-      <div className="mx-auto lg:col-span-2">
+    <section className="px-4 pb-10">
+      <h2 className="mb-10 text-center text-5xl text-white">
+        Manage Subscribers
+      </h2>
+      <div className="mb-10">
+        <h3 className="mb-10 pt-8 text-center text-lg uppercase">
+          Add Subscriber
+        </h3>
+        <NewSubscriberForm />
+      </div>
+      <div className="mb-10">
+        <h3 className="mb-10 pt-8 text-center text-lg uppercase">
+          Subscribers
+        </h3>
         <SubscriberList subscribers={subscriberList} />
       </div>
     </section>

--- a/src/app/(public-pages)/deals/add/schemas.tsx
+++ b/src/app/(public-pages)/deals/add/schemas.tsx
@@ -58,7 +58,6 @@ export const newDealInitialValuesSchema = z.object({
 })
 
 export const newAdminUserSchema = z.object({
-  userId: z.string().min(1, 'Please enter a valid user ID'),
   email: z.string().email('Please enter a valid email'),
 })
 

--- a/src/app/(public-pages)/deals/add/schemas.tsx
+++ b/src/app/(public-pages)/deals/add/schemas.tsx
@@ -57,6 +57,15 @@ export const newDealInitialValuesSchema = z.object({
   contactEmail: z.string().optional(),
 })
 
+export const newAdminUserSchema = z.object({
+  userId: z.string().min(1, 'Please enter a valid user ID'),
+  email: z.string().email('Please enter a valid email'),
+})
+
+export const newSubscriberSchema = z.object({
+  email: z.string().email('Please enter a valid email'),
+})
+
 export type ProductInfoType = z.infer<typeof productInfoSchema>
 export type CouponDetailsType = z.infer<typeof couponDetailsSchema>
 export type ContactDetailsType = z.infer<typeof contactDetailsSchema>

--- a/src/components/dashboard/AdminNav.tsx
+++ b/src/components/dashboard/AdminNav.tsx
@@ -22,6 +22,12 @@ export default function AdminNav() {
           >
             <span className="hidden md:inline">Manage</span> Subscribers
           </Link>
+          <Link
+            className=" rounded p-2 text-lg transition-colors hover:bg-gray-700 hover:no-underline "
+            href="/dashboard/admins"
+          >
+            <span className="hidden md:inline">Manage</span> Admins
+          </Link>
         </div>
       </div>
       <div className="flex flex-col items-center gap-x-4 gap-y-4 md:flex-row">

--- a/src/components/dashboard/SubmitButton.tsx
+++ b/src/components/dashboard/SubmitButton.tsx
@@ -15,7 +15,7 @@ export default function SubmitButton({
   const { pending } = useFormStatus()
   return (
     <button
-      className="mt-2 rounded-lg bg-teal-500 py-4 text-lg text-black disabled:bg-teal-600/30 lg:-mt-4 lg:py-7 lg:text-2xl"
+      className="mt-2 rounded-lg bg-teal-500 px-10 py-4 text-lg text-black disabled:bg-teal-600/30 lg:-mt-4 lg:py-7 lg:text-2xl"
       type="submit"
       onClick={handleClick}
     >

--- a/src/components/dashboard/admin/AdminList.tsx
+++ b/src/components/dashboard/admin/AdminList.tsx
@@ -1,0 +1,23 @@
+import { AdminUser } from '@prisma/client'
+import DeleteButton from './DeleteButton'
+import SubscribeForm from '@/components/forms/SubscribeForm'
+
+interface AdminsProps {
+  admins: AdminUser[]
+}
+
+export default function AdminUserList({ admins }: AdminsProps) {
+  return (
+    <ul className="grid w-full gap-2 gap-y-4">
+      {admins.map((admin) => (
+        <li
+          key={admin.email + admin.xata_id}
+          className="flex items-center gap-x-4"
+        >
+          {admin.email}
+          <DeleteButton id={admin.xata_id} />
+        </li>
+      ))}
+    </ul>
+  )
+}

--- a/src/components/dashboard/admin/DeleteButton.tsx
+++ b/src/components/dashboard/admin/DeleteButton.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { deleteSubscriberAction } from '@/actions/dashboard/subscriber'
+import { deleteAdminUserAction } from '@/actions/dashboard/adminUser'
 import toast from 'react-hot-toast'
 
 export default function DeleteButton({ id }: { id: string }) {
@@ -9,7 +9,7 @@ export default function DeleteButton({ id }: { id: string }) {
       className="cursor text-red-600"
       type="button"
       onClick={async () => {
-        const res = await deleteSubscriberAction(id)
+        const res = await deleteAdminUserAction(id)
         if (res.message) {
           if (!res.success) {
             toast.error(res.message)

--- a/src/components/dashboard/admin/NewAdminForm.tsx
+++ b/src/components/dashboard/admin/NewAdminForm.tsx
@@ -28,7 +28,6 @@ export default function NewAdminForm() {
       <div className="">
         <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
           <Input label="Email" name="email" type="email" required={true} />
-          <Input label="User Id" name="userId" type="text" required={true} />
         </div>
         <SubmitButton text="Submit" handleClick={() => {}} />
       </div>

--- a/src/components/dashboard/admin/NewAdminForm.tsx
+++ b/src/components/dashboard/admin/NewAdminForm.tsx
@@ -1,0 +1,37 @@
+'use client'
+import toast from 'react-hot-toast'
+import SubmitButton from '../SubmitButton'
+import Input from '../../forms/add-a-deal/Input'
+import { createAdminUserAction } from '@/actions/dashboard/adminUser'
+import { useRef } from 'react'
+
+const initialState = {}
+export default function NewAdminForm() {
+  const formRef = useRef<HTMLFormElement>(null)
+
+  return (
+    <form
+      id="new-admin-form"
+      ref={formRef}
+      action={async (formData) => {
+        const res = await createAdminUserAction(formData)
+        if (res.message) {
+          if (res.success) {
+            toast.success(res.message)
+            formRef.current?.reset()
+          } else {
+            toast.error(res.message)
+          }
+        }
+      }}
+    >
+      <div className="">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+          <Input label="Email" name="email" type="email" required={true} />
+          <Input label="User Id" name="userId" type="text" required={true} />
+        </div>
+        <SubmitButton text="Submit" handleClick={() => {}} />
+      </div>
+    </form>
+  )
+}

--- a/src/components/dashboard/subscribers/NewSubscriberForm.tsx
+++ b/src/components/dashboard/subscribers/NewSubscriberForm.tsx
@@ -1,0 +1,37 @@
+'use client'
+import toast from 'react-hot-toast'
+import SubmitButton from '../SubmitButton'
+import Input from '../../forms/add-a-deal/Input'
+
+import { useRef } from 'react'
+import { createSubscriberAction } from '@/actions/dashboard/subscriber'
+
+const initialState = {}
+export default function NewSubscriberForm() {
+  const formRef = useRef<HTMLFormElement>(null)
+
+  return (
+    <form
+      id="subscribe-form"
+      ref={formRef}
+      action={async (formData) => {
+        const res = await createSubscriberAction(formData)
+        if (res.message) {
+          if (res.success) {
+            toast.success(res.message)
+            formRef.current?.reset()
+          } else {
+            toast.error(res.message)
+          }
+        }
+      }}
+    >
+      <div className="">
+        <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
+          <Input label="Email" name="email" type="email" required={true} />
+        </div>
+        <SubmitButton text="Submit" handleClick={() => {}} />
+      </div>
+    </form>
+  )
+}

--- a/src/components/subscriber/SubscriberList.tsx
+++ b/src/components/subscriber/SubscriberList.tsx
@@ -8,21 +8,16 @@ interface SubscribersProps {
 
 export default function SubscriberList({ subscribers }: SubscribersProps) {
   return (
-    <div className="mx-auto flex flex-col space-y-8 text-center text-white">
-      <h3 className="text-md uppercase">Add a Subscriber</h3>
-      <SubscribeForm />
-      <h3 className="text-md pt-8 uppercase">Subscriber List</h3>
-      <ul className="grid w-full gap-2">
-        {subscribers.map((subscriber) => (
-          <li
-            key={subscriber.email + subscriber.xata_id}
-            className="flex w-full justify-between border border-gray-800 px-2 py-1 transition-all duration-300 ease-in-out hover:scale-105 hover:border-teal-500"
-          >
-            {subscriber.email}
-            <DeleteButton id={subscriber.xata_id} />
-          </li>
-        ))}
-      </ul>
-    </div>
+    <ul className="grid w-full gap-y-4">
+      {subscribers.map((subscriber) => (
+        <li
+          key={subscriber.email + subscriber.xata_id}
+          className="flex items-center gap-x-4"
+        >
+          {subscriber.email}
+          <DeleteButton id={subscriber.xata_id} />
+        </li>
+      ))}
+    </ul>
   )
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -354,12 +354,3 @@ export async function updateSubscriberToVerified(
     },
   })
 }
-
-//ADMIN QUERIES
-export const getAdminUserById = async (userId: string) => {
-  return await prisma.adminUser.findUnique({
-    where: {
-      userId,
-    },
-  })
-}

--- a/src/queries/adminUsers.ts
+++ b/src/queries/adminUsers.ts
@@ -1,0 +1,47 @@
+import prisma from '@/lib/db'
+import { AdminUser } from '@prisma/client'
+
+export async function getAllAdminUsers(
+  limit: number = 20
+): Promise<AdminUser[]> {
+  return await prisma.adminUser.findMany({
+    take: limit,
+    orderBy: {
+      xata_createdat: 'desc',
+    },
+  })
+}
+
+export async function deleteAdminUser(id: string): Promise<void> {
+  await prisma.adminUser.delete({
+    where: {
+      xata_id: id,
+    },
+  })
+}
+
+export const getAdminUserById = async (userId: string) => {
+  return await prisma.adminUser.findUnique({
+    where: {
+      userId,
+    },
+  })
+}
+
+export const getSuperAdminUserById = async (userId: string) => {
+  return await prisma.adminUser.findUnique({
+    where: {
+      userId,
+      isSuperAdmin: true,
+    },
+  })
+}
+
+export const createAdminUser = async (email: string, userId: string) => {
+  return await prisma.adminUser.create({
+    data: {
+      email,
+      userId,
+    },
+  })
+}

--- a/src/queries/adminUsers.ts
+++ b/src/queries/adminUsers.ts
@@ -20,28 +20,27 @@ export async function deleteAdminUser(id: string): Promise<void> {
   })
 }
 
-export const getAdminUserById = async (userId: string) => {
+export const getAdminUserById = async (email: string) => {
   return await prisma.adminUser.findUnique({
     where: {
-      userId,
+      email,
     },
   })
 }
 
-export const getSuperAdminUserById = async (userId: string) => {
+export const getSuperAdminUserById = async (email: string) => {
   return await prisma.adminUser.findUnique({
     where: {
-      userId,
+      email,
       isSuperAdmin: true,
     },
   })
 }
 
-export const createAdminUser = async (email: string, userId: string) => {
+export const createAdminUser = async (email: string) => {
   return await prisma.adminUser.create({
     data: {
       email,
-      userId,
     },
   })
 }

--- a/src/types/Types.ts
+++ b/src/types/Types.ts
@@ -47,7 +47,12 @@ export type NewSubscriberData = {
   status: string
 }
 
-export type ReturnValue<T> = { data: T } | { error: string }
+export type ReturnValue<T> = {
+  data?: T
+  message?: string
+  success: boolean
+  error?: Error
+}
 
 export enum ImageUploadStatus {
   PENDING = 'PENDING',

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,7 +1,13 @@
-import { getAdminUserById } from '@/lib/queries'
+import { getAdminUserById, getSuperAdminUserById } from '@/queries/adminUsers'
 
 export const isAdminUser = async (userId: string): Promise<boolean> => {
   if (!userId) return false
   const adminUser = await getAdminUserById(userId)
+  return !!adminUser
+}
+
+export const isSuperAdminUser = async (userId: string): Promise<boolean> => {
+  if (!userId) return false
+  const adminUser = await getSuperAdminUserById(userId)
   return !!adminUser
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -1,13 +1,13 @@
 import { getAdminUserById, getSuperAdminUserById } from '@/queries/adminUsers'
 
-export const isAdminUser = async (userId: string): Promise<boolean> => {
-  if (!userId) return false
-  const adminUser = await getAdminUserById(userId)
+export const isAdminUser = async (email: string): Promise<boolean> => {
+  if (!email) return false
+  const adminUser = await getAdminUserById(email)
   return !!adminUser
 }
 
-export const isSuperAdminUser = async (userId: string): Promise<boolean> => {
-  if (!userId) return false
-  const adminUser = await getSuperAdminUserById(userId)
+export const isSuperAdminUser = async (email: string): Promise<boolean> => {
+  if (!email) return false
+  const adminUser = await getSuperAdminUserById(email)
   return !!adminUser
 }


### PR DESCRIPTION

## Description
Add admin features to manage admin

- updated DB schema to use `xata_id` as primary key for `AdminUser` table
- added `email` property to `AdminUser` table
- added dashboard page for managing admins
- created new admin form
- created admin list with delete functionality using server actions
- refactored subscriber dashboard page to match admin page (more design work to come)


## Screenshot

https://github.com/user-attachments/assets/e7d1f722-b5a2-4f27-bec7-8ac89f6687c2



## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [ ] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ ] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ ] The `Description` gives a good representation of the changes made
- [ ] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->