### PR TITLE
Feat: reconfigure deal visit tracking and dashboard layouts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@react-email/tailwind": "^0.0.14",
         "@sentry/nextjs": "^7.106.1",
         "@t3-oss/env-nextjs": "^0.9.2",
+        "@tailwindcss/container-queries": "^0.1.1",
         "@tanstack/react-table": "^8.12.0",
         "@types/uuid": "^9.0.8",
         "@vercel/analytics": "^1.2.2",
@@ -3732,6 +3733,14 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
       }
     },
     "node_modules/@tanstack/react-table": {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@react-email/tailwind": "^0.0.14",
     "@sentry/nextjs": "^7.106.1",
     "@t3-oss/env-nextjs": "^0.9.2",
+    "@tailwindcss/container-queries": "^0.1.1",
     "@tanstack/react-table": "^8.12.0",
     "@types/uuid": "^9.0.8",
     "@vercel/analytics": "^1.2.2",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,7 +27,16 @@ model Deal {
   endDate        DateTime? @db.Date
   startDate      DateTime  @default(now())
   tags           Tag[]     @relation("DealToTag")
-  clicks        Int       @default(0)
+  views          DealView[]
+}
+
+model DealView {
+  xata_id        String   @id @unique(map: "DealView__pgroll_new_xata_id_key") @default(dbgenerated("('rec_'::text || (xata_private.xid())::text)"))
+  xata_version   Int      @default(0)
+  xata_createdat DateTime @default(now()) @db.Timestamptz(6)
+  xata_updatedat DateTime @default(now()) @db.Timestamptz(6)
+  deal           Deal     @relation(fields: [dealId], references: [xata_id])
+  dealId         String
 }
 
 model Tag {

--- a/src/app/(admin)/dashboard/PendingDeals.tsx
+++ b/src/app/(admin)/dashboard/PendingDeals.tsx
@@ -1,8 +1,13 @@
 import AdminDealsList from '@/components/dashboard/AdminDealsList'
 import { getPendingAdminDeals } from '@/lib/queries'
 
-export default async function PendingAdminDeals() {
-  const pendingDeals = await getPendingAdminDeals()
+interface PendingAdminDealsProps {
+  limit?: number
+}
+export default async function PendingAdminDeals({
+  limit,
+}: PendingAdminDealsProps) {
+  const pendingDeals = await getPendingAdminDeals(limit)
 
   return (
     <>

--- a/src/app/(admin)/dashboard/admins/page.tsx
+++ b/src/app/(admin)/dashboard/admins/page.tsx
@@ -1,13 +1,13 @@
 import AdminUserList from '@/components/dashboard/admin/AdminList'
 import NewAdminForm from '@/components/dashboard/admin/NewAdminForm'
+import DashboardPage from '@/components/dashboard/DashboardPage'
 import { getAllAdminUsers } from '@/queries/adminUsers'
 
 export default async function Subscribers() {
   const admins = await getAllAdminUsers()
 
   return (
-    <section className="px-4 pb-10">
-      <h2 className="mb-10 text-center text-5xl text-white">Manage Admins</h2>
+    <DashboardPage heading="Manage Admins">
       <div className="mb-10">
         <h3 className="mb-10 pt-8 text-center text-lg uppercase">
           Add Admin User
@@ -20,6 +20,6 @@ export default async function Subscribers() {
         </h3>
         <AdminUserList admins={admins} />
       </div>
-    </section>
+    </DashboardPage>
   )
 }

--- a/src/app/(admin)/dashboard/deals/[id]/page.tsx
+++ b/src/app/(admin)/dashboard/deals/[id]/page.tsx
@@ -51,14 +51,12 @@ export default async function EditDealPage({
   }
 
   return (
-    <main>
-      <section className="mx-auto space-y-12 px-4 pb-10">
-        <div className="flex flex-col items-center justify-between gap-y-4 sm:flex-row">
-          <h1 className="text-center text-5xl text-white">Edit Deal</h1>
-          <DeleteDealButton id={id} />
-        </div>
-        <EditDealForm deal={deal} />
-      </section>
-    </main>
+    <section>
+      <div className="mb-10 flex flex-col items-center justify-between gap-y-4 sm:flex-row ">
+        <h1 className="text-center text-5xl text-white">Edit Deal</h1>
+        <DeleteDealButton id={id} />
+      </div>
+      <EditDealForm deal={deal} />
+    </section>
   )
 }

--- a/src/app/(admin)/dashboard/deals/featured/page.tsx
+++ b/src/app/(admin)/dashboard/deals/featured/page.tsx
@@ -1,12 +1,12 @@
 import ManageDealsNav from '@/components/dashboard/ManageDealsNav'
 import FeaturedAdminDeals from '../../FeaturedDeals'
+import DashboardPage from '@/components/dashboard/DashboardPage'
 
 export default async function FeaturedDeals() {
   return (
-    <section>
-      <h1 className="mb-12 text-center text-5xl text-white">Featured Deals</h1>
+    <DashboardPage heading="Manage Deals">
       <ManageDealsNav tabIndex={3} />
       <FeaturedAdminDeals />
-    </section>
+    </DashboardPage>
   )
 }

--- a/src/app/(admin)/dashboard/deals/page.tsx
+++ b/src/app/(admin)/dashboard/deals/page.tsx
@@ -1,12 +1,12 @@
 import ManageDealsNav from '@/components/dashboard/ManageDealsNav'
-import ApprovedAdminDeals from '../../ApprovedDeals'
+import AllAdminDeals from '../AllDeals'
 import DashboardPage from '@/components/dashboard/DashboardPage'
 
-export default async function ApprovedDeals() {
+export default async function Deals() {
   return (
     <DashboardPage heading="Manage Deals">
-      <ManageDealsNav tabIndex={1} />
-      <ApprovedAdminDeals />
+      <ManageDealsNav tabIndex={0} />
+      <AllAdminDeals />
     </DashboardPage>
   )
 }

--- a/src/app/(admin)/dashboard/deals/pending/page.tsx
+++ b/src/app/(admin)/dashboard/deals/pending/page.tsx
@@ -1,12 +1,12 @@
 import ManageDealsNav from '@/components/dashboard/ManageDealsNav'
 import PendingAdminDeals from '../../PendingDeals'
+import DashboardPage from '@/components/dashboard/DashboardPage'
 
 export default async function PendingDeals() {
   return (
-    <section>
-      <h1 className="mb-12 text-center text-5xl text-white">Pending Deals</h1>
+    <DashboardPage heading="Manage Deals">
       <ManageDealsNav tabIndex={2} />
       <PendingAdminDeals />
-    </section>
+    </DashboardPage>
   )
 }

--- a/src/app/(admin)/dashboard/deals/reported/page.tsx
+++ b/src/app/(admin)/dashboard/deals/reported/page.tsx
@@ -1,12 +1,11 @@
+import DashboardPage from '@/components/dashboard/DashboardPage'
 import ManageDealsNav from '@/components/dashboard/ManageDealsNav'
 
 export default async function Deals() {
   return (
-    <section>
-      <h1 className="mb-12 text-center text-5xl text-white">
-        Reported Deals (coming soon)
-      </h1>
+    <DashboardPage heading="Manage Deals">
       <ManageDealsNav tabIndex={4} />
-    </section>
+      <p>Coming soon!</p>
+    </DashboardPage>
   )
 }

--- a/src/app/(admin)/dashboard/layout.tsx
+++ b/src/app/(admin)/dashboard/layout.tsx
@@ -22,11 +22,10 @@ export default async function Home({
   }
 
   return (
-    <div className="min-h-screen bg-gray-900 text-white">
-      <div className="h-full w-52 md:w-80">
-        <AdminNav />
-      </div>
-      <main className=" ml-52 px-4 py-20 md:ml-80 md:px-8">{children}</main>
+    <div className="flex min-h-screen bg-gray-900 text-white">
+      <div className="h-full min-h-screen w-72 px-6"></div>
+      <AdminNav />
+      <main className=" w-full px-4 py-20  md:px-16">{children}</main>
     </div>
   )
 }

--- a/src/app/(admin)/dashboard/metrics/page.tsx
+++ b/src/app/(admin)/dashboard/metrics/page.tsx
@@ -1,0 +1,14 @@
+import DashboardPage from '@/components/dashboard/DashboardPage'
+import DealListByViews from '@/components/dashboard/metrics/DealListByViews'
+
+export default async function MetricsPage() {
+  return (
+    <DashboardPage heading="Metrics">
+      <div className="mb-10"></div>
+      <div className="mb-10">
+        <h3 className="mb-10 pt-8 text-center text-lg uppercase">Top Deals</h3>
+        <DealListByViews />
+      </div>
+    </DashboardPage>
+  )
+}

--- a/src/app/(admin)/dashboard/page.tsx
+++ b/src/app/(admin)/dashboard/page.tsx
@@ -1,12 +1,43 @@
-import ManageDealsNav from '@/components/dashboard/ManageDealsNav'
-import AllAdminDeals from './AllDeals'
+import DashboardCard from '@/components/dashboard/DashboardCard'
+import PendingAdminDeals from './PendingDeals'
+import DealListByViews from '@/components/dashboard/metrics/DealListByViews'
+import Link from 'next/link'
 
-export default async function Deals() {
+export default async function RootDashboardPage() {
   return (
     <section>
-      <h1 className="mb-12 text-center text-5xl text-white">All Deals</h1>
-      <ManageDealsNav tabIndex={0} />
-      <AllAdminDeals />
+      <h1 className="mb-12 text-center text-5xl text-white">Dashboard</h1>
+      <div className="grid grid-cols-2 gap-8">
+        <DashboardCard heading="Pending Deals">
+          <div className="mb-6">
+            <PendingAdminDeals limit={5} />
+          </div>
+          <div className="flex justify-end">
+            <Link
+              className="text-right underline transition-colors hover:text-teal-500"
+              href="/dashboard/deals/pending"
+            >
+              View All Pending Deals
+            </Link>
+          </div>
+        </DashboardCard>
+        <DashboardCard heading="Top Deals">
+          <div className="mb-6">
+            <DealListByViews limit={5} />
+          </div>
+          <div className="flex justify-end">
+            <Link
+              className="text-right underline transition-colors hover:text-teal-500"
+              href="/dashboard/metrics"
+            >
+              View All Metrics
+            </Link>
+          </div>
+        </DashboardCard>
+        <DashboardCard heading="Reported Deals">
+          <p>Coming soon</p>
+        </DashboardCard>
+      </div>
     </section>
   )
 }

--- a/src/app/(admin)/dashboard/subscribers/page.tsx
+++ b/src/app/(admin)/dashboard/subscribers/page.tsx
@@ -1,6 +1,7 @@
 import { getAllSubscribers } from '@/lib/queries'
 import SubscriberList from '@/components/subscriber/SubscriberList'
 import NewSubscriberForm from '@/components/dashboard/subscribers/NewSubscriberForm'
+import DashboardPage from '@/components/dashboard/DashboardPage'
 
 export default async function Subscribers() {
   // fetch all subscribers
@@ -9,10 +10,7 @@ export default async function Subscribers() {
   const subscriberList = JSON.parse(JSON.stringify(subscribers))
 
   return (
-    <section className="px-4 pb-10">
-      <h2 className="mb-10 text-center text-5xl text-white">
-        Manage Subscribers
-      </h2>
+    <DashboardPage heading="Manage Subscribers">
       <div className="mb-10">
         <h3 className="mb-10 pt-8 text-center text-lg uppercase">
           Add Subscriber
@@ -25,6 +23,6 @@ export default async function Subscribers() {
         </h3>
         <SubscriberList subscribers={subscriberList} />
       </div>
-    </section>
+    </DashboardPage>
   )
 }

--- a/src/app/(public-pages)/deals/[id]/not-found.tsx
+++ b/src/app/(public-pages)/deals/[id]/not-found.tsx
@@ -6,7 +6,7 @@ export default function Deal404() {
   return (
     <main>
       <div className="pb-10">
-        <PageHeader title="Deal not found" />
+        <PageHeader heading="Deal not found" />
         <Link className="text-lg text-white underline" href="/deals">
           Back to all deals
         </Link>

--- a/src/app/(public-pages)/deals/add/layout.tsx
+++ b/src/app/(public-pages)/deals/add/layout.tsx
@@ -11,8 +11,8 @@ export default function DealsLayout({
     <AddDealContextProvider>
       <main className="px-2 lg:px-0">
         <PageHeader
-          title="Share a Deal"
-          subtitle="Have an amazing deal or discount tailored for developers? Let us know!"
+          heading="Share a Deal"
+          subheading="Have an amazing deal or discount tailored for developers? Let us know!"
         />
 
         {children}

--- a/src/app/(public-pages)/deals/category/[category]/page.tsx
+++ b/src/app/(public-pages)/deals/category/[category]/page.tsx
@@ -35,9 +35,7 @@ export default async function CategoryPage({
   }
   return (
     <main>
-      <div className="pb-10">
-        <PageHeader title={`${capitalizedCategory} Deals`} />
-      </div>
+      <PageHeader heading={`${capitalizedCategory} Deals`} />
       <div className="pb-10">
         <CategoryOptions />
       </div>

--- a/src/app/(public-pages)/deals/page.tsx
+++ b/src/app/(public-pages)/deals/page.tsx
@@ -11,9 +11,7 @@ export default async function DealsPage() {
   //TODO: handle error
   return (
     <main>
-      <div className="pb-10">
-        <PageHeader title="All Deals" />
-      </div>
+      <PageHeader heading="All Deals" />
       <div className="pb-10">
         <CategoryOptions />
       </div>

--- a/src/app/(public-pages)/disclaimer/page.tsx
+++ b/src/app/(public-pages)/disclaimer/page.tsx
@@ -4,10 +4,8 @@ export const revalidate = 120
 
 export default async function Disclaimer() {
   return (
-    <div>
-      <div className="pb-10">
-        <PageHeader title="Disclaimer" />
-      </div>
+    <>
+      <PageHeader heading="Disclaimer" />
       <div className="pb-10">
         <p className=" text-lrg text-gray-300">
           Some deals may include affiliate links. Proceeds from these affiliate
@@ -15,6 +13,6 @@ export default async function Disclaimer() {
           on courses and other resources.
         </p>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/app/api/tracking/route.ts
+++ b/src/app/api/tracking/route.ts
@@ -1,18 +1,17 @@
 import { NextRequest } from 'next/server'
 import { redirect } from 'next/navigation'
-import { incrementDealClicks } from '@/lib/queries'
+import { createDealView } from '@/queries/dealView'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
   const url = searchParams.get('url')
   const id = searchParams.get('id')
-  console.log(url, id)
   if (!url || !id) {
     redirect('/')
   }
 
   try {
-    await incrementDealClicks(id)
+    await createDealView(id)
   } catch (error) {
     console.error(error)
   } finally {

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,22 +1,22 @@
 import React from 'react'
 
 export default function PageHeader({
-  title,
-  subtitle,
+  heading,
+  subheading,
 }: {
-  title: string
-  subtitle?: string
+  heading: string
+  subheading?: string
 }) {
   return (
-    <>
+    <div className="mb-10">
       <h1 className="mb-4 text-4xl font-semibold text-white md:text-7xl">
-        {title}
+        {heading}
       </h1>
-      {subtitle && (
+      {subheading && (
         <span className="text-sm font-light text-white md:text-2xl">
-          {subtitle}
+          {subheading}
         </span>
       )}
-    </>
+    </div>
   )
 }

--- a/src/components/dashboard/AdminDealsList.tsx
+++ b/src/components/dashboard/AdminDealsList.tsx
@@ -1,45 +1,69 @@
 import { Deal } from '@prisma/client'
 import { format } from 'date-fns'
 import Link from 'next/link'
-import Separator from '../Separator'
 import DealImage from '../deals/DealImage'
 import { Category } from '@/types/Types'
-import { cn } from '@/lib/utils'
 
 export default function AdminDealsList({ deals }: { deals: Deal[] }) {
   return (
-    <div className="flex flex-col items-stretch">
-      {deals.map((deal) => (
-        <div key={deal.xata_id}>
-          <Link
-            className="text-xl font-bold hover:text-teal-500"
-            href={`/dashboard/deals/${deal.xata_id}`}
-          >
-            <div className="flex flex-row items-center gap-x-4">
-              <div
-                className={cn(
-                  'hidden h-4 w-4 rounded-full lg:block',
-                  deal.approved ? 'bg-green-500' : 'bg-yellow-500'
-                )}
-              ></div>
-              <div className="hidden w-32 lg:block">
-                <DealImage
-                  coverImageURL={deal.coverImageURL}
-                  category={deal.category as Category}
-                  name={deal.name}
-                />
-              </div>
-              <span className="mr-4 hidden w-32 text-lg text-slate-400 lg:inline">
-                {format(new Date(deal.xata_createdat), 'MMM d')}
-              </span>
-              {deal.name}
-            </div>
-          </Link>
-          <div className="my-4 ">
-            <Separator />
-          </div>
-        </div>
-      ))}
+    <div className="@container relative overflow-x-auto">
+      <table className="w-full rounded-md text-left text-sm text-gray-400 ">
+        <thead className=" bg-gray-700 text-xs uppercase text-gray-400">
+          <tr>
+            <th scope="col" className="@[700px]:underline px-6 py-3">
+              Deal
+            </th>
+            <th
+              scope="col"
+              className="@[700px]:table-cell hidden w-20 px-6 py-3"
+            >
+              Owner
+            </th>
+            <th scope="col" className="w-40 px-6 py-3">
+              Created
+            </th>
+            <th scope="col" className="w-32 px-6 py-3">
+              Status
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {deals.map((deal) => (
+            <tr
+              className="border-b border-gray-700 bg-gray-800"
+              key={deal.xata_id}
+            >
+              <td
+                scope="row"
+                className="flex items-center gap-x-4 whitespace-nowrap px-6 py-4 font-medium text-white"
+              >
+                <div className="@[700px]:block hidden w-32">
+                  <DealImage
+                    coverImageURL={deal.coverImageURL}
+                    category={deal.category as Category}
+                    name={deal.name}
+                  />
+                </div>
+                <Link
+                  className="transition-colors hover:text-teal-500"
+                  href={`/deals/${deal.xata_id}`}
+                >
+                  {deal.name}
+                </Link>
+              </td>
+              <td className="@[700px]:table-cell hidden w-20 text-ellipsis whitespace-nowrap px-6 py-4">
+                {deal.contactName}
+              </td>
+              <td className="px-6 py-4">
+                {format(new Date(deal.xata_createdat), 'MMM d, yyyy')}
+              </td>
+              <td className="px-6 py-4">
+                {deal.approved ? 'Approved' : 'Pending'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </div>
   )
 }

--- a/src/components/dashboard/AdminNav.tsx
+++ b/src/components/dashboard/AdminNav.tsx
@@ -6,31 +6,41 @@ export default function AdminNav() {
   const { isLoaded, user } = useUser()
 
   return (
-    <div className="fixed flex h-screen w-52 flex-col justify-between gap-y-10 bg-gray-800 px-6 py-20 text-white md:w-80">
+    <div className="fixed flex h-screen w-60 flex-col justify-between gap-y-10 bg-gray-800 px-6 py-20 text-white ">
       <div>
-        <h1 className="mb-10 pl-2 text-3xl font-light text-white/70">Admin</h1>
-        <div className="flex flex-col items-stretch gap-y-4">
+        <Link href="/dashboard">
+          <h1 className="mb-10 pl-2 text-3xl font-light text-white/70">
+            Admin
+          </h1>
+        </Link>
+        <div className="flex flex-col items-stretch gap-y-3">
           <Link
             className=" rounded p-2 text-lg transition-colors hover:bg-gray-700 hover:no-underline "
-            href="/dashboard"
+            href="/dashboard/deals"
           >
-            <span className="hidden md:inline">Manage</span> Deals
+            Deals
           </Link>
           <Link
             className=" rounded p-2 text-lg transition-colors hover:bg-gray-700 hover:no-underline "
             href="/dashboard/subscribers"
           >
-            <span className="hidden md:inline">Manage</span> Subscribers
+            Subscribers
           </Link>
           <Link
             className=" rounded p-2 text-lg transition-colors hover:bg-gray-700 hover:no-underline "
             href="/dashboard/admins"
           >
-            <span className="hidden md:inline">Manage</span> Admins
+            Admins
+          </Link>
+          <Link
+            className=" rounded p-2 text-lg transition-colors hover:bg-gray-700 hover:no-underline "
+            href="/dashboard/metrics"
+          >
+            Metrics
           </Link>
         </div>
       </div>
-      <div className="flex flex-col items-center gap-x-4 gap-y-4 md:flex-row">
+      <div className="flex flex-col items-center gap-x-4 gap-y-4">
         <UserButton />
         <div>
           {isLoaded && user?.fullName && <p className="">{user.fullName}</p>}

--- a/src/components/dashboard/DashboardCard.tsx
+++ b/src/components/dashboard/DashboardCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+interface DashboardCardProps {
+  children?: React.ReactNode
+  heading: string
+}
+
+export default function DashboardCard({
+  children,
+  heading,
+}: DashboardCardProps) {
+  return (
+    <div className="rounded-md bg-gray-800 px-10 py-10">
+      <h2 className="mb-10 text-center text-2xl">{heading}</h2>
+      {children}
+    </div>
+  )
+}

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import PageHeader from '../PageHeader'
+
+interface DashboardCardProps {
+  children?: React.ReactNode
+  heading: string
+}
+
+export default function DashboardCard({
+  children,
+  heading,
+}: DashboardCardProps) {
+  return (
+    <section>
+      <PageHeader heading={heading} />
+      {children}
+    </section>
+  )
+}

--- a/src/components/dashboard/ManageDealsNav.tsx
+++ b/src/components/dashboard/ManageDealsNav.tsx
@@ -7,7 +7,7 @@ interface ManageDealsNavProps {
 }
 export default function ManageDealsNav({ tabIndex }: ManageDealsNavProps) {
   const links = [
-    { href: '/dashboard', text: 'All' },
+    { href: '/dashboard/deals', text: 'All' },
     { href: '/dashboard/deals/approved', text: 'Approved' },
     { href: '/dashboard/deals/pending', text: 'Pending' },
     { href: '/dashboard/deals/featured', text: 'Featured' },

--- a/src/components/dashboard/metrics/DealListByViews.tsx
+++ b/src/components/dashboard/metrics/DealListByViews.tsx
@@ -1,12 +1,12 @@
-import { AdminUser } from '@prisma/client'
-import DeleteButton from './DeleteButton'
-import SubscribeForm from '@/components/forms/SubscribeForm'
+import { getViewsByDeal } from '@/queries/dealView'
+import Link from 'next/link'
+import React from 'react'
 
-interface AdminsProps {
-  admins: AdminUser[]
+interface DealListByViewsProps {
+  limit?: number
 }
-
-export default function AdminUserList({ admins }: AdminsProps) {
+export default async function DealListByViews({ limit }: DealListByViewsProps) {
+  const viewsByDeal = await getViewsByDeal(limit)
   return (
     <div className="relative overflow-x-auto">
       <table className="w-full rounded-md text-left text-sm text-gray-400 ">
@@ -16,25 +16,28 @@ export default function AdminUserList({ admins }: AdminsProps) {
               Name
             </th>
             <th scope="col" className="w-32 px-6 py-3">
-              Manage
+              Views
             </th>
           </tr>
         </thead>
         <tbody>
-          {admins.map((admin) => (
+          {viewsByDeal.map((deal) => (
             <tr
               className="border-b border-gray-700 bg-gray-800"
-              key={admin.xata_id}
+              key={deal.xata_id}
             >
               <th
                 scope="row"
                 className="whitespace-nowrap px-6 py-4 font-medium text-white"
               >
-                {admin.email}
+                <Link
+                  className="transition-colors hover:text-teal-500"
+                  href={`/deals/${deal.xata_id}`}
+                >
+                  {deal.name}
+                </Link>
               </th>
-              <td className="px-6 py-4">
-                <DeleteButton id={admin.xata_id} />
-              </td>
+              <td className="px-6 py-4">{deal._count.views}</td>
             </tr>
           ))}
         </tbody>

--- a/src/components/deals/ApprovedDeals.tsx
+++ b/src/components/deals/ApprovedDeals.tsx
@@ -2,7 +2,12 @@ import { getApprovedAdminDeals, getApprovedDeals } from '@/lib/queries'
 import React from 'react'
 import DealsList from './DealsList'
 
-export default async function ApprovedAdminDeals() {
-  const deals = await getApprovedAdminDeals()
+interface ApprovedAdminDealsProps {
+  limit?: number
+}
+export default async function ApprovedAdminDeals({
+  limit,
+}: ApprovedAdminDealsProps) {
+  const deals = await getApprovedAdminDeals(limit)
   return <DealsList deals={deals} />
 }

--- a/src/components/deals/DealImage.tsx
+++ b/src/components/deals/DealImage.tsx
@@ -1,5 +1,4 @@
 import { Category } from '@/types/Types'
-import { Deal } from '@prisma/client'
 import React from 'react'
 import DealGradientPlaceholder from './DealGradientPlaceholder'
 import Image from 'next/image'

--- a/src/components/deals/FeaturedDeals.tsx
+++ b/src/components/deals/FeaturedDeals.tsx
@@ -1,7 +1,10 @@
 import DealsList from './DealsList'
 import { getApprovedFeaturedDeals } from '@/lib/queries'
 
-export default async function FeaturedDeals() {
-  const deals = await getApprovedFeaturedDeals()
+interface FeaturedDealsProps {
+  limit?: number
+}
+export default async function FeaturedDeals({ limit }: FeaturedDealsProps) {
+  const deals = await getApprovedFeaturedDeals(limit)
   return <DealsList deals={deals} />
 }

--- a/src/components/subscriber/SubscriberList.tsx
+++ b/src/components/subscriber/SubscriberList.tsx
@@ -8,16 +8,37 @@ interface SubscribersProps {
 
 export default function SubscriberList({ subscribers }: SubscribersProps) {
   return (
-    <ul className="grid w-full gap-y-4">
-      {subscribers.map((subscriber) => (
-        <li
-          key={subscriber.email + subscriber.xata_id}
-          className="flex items-center gap-x-4"
-        >
-          {subscriber.email}
-          <DeleteButton id={subscriber.xata_id} />
-        </li>
-      ))}
-    </ul>
+    <div className="relative overflow-x-auto">
+      <table className="w-full rounded-md text-left text-sm text-gray-400 ">
+        <thead className=" bg-gray-700 text-xs uppercase text-gray-400">
+          <tr>
+            <th scope="col" className="px-6 py-3">
+              Name
+            </th>
+            <th scope="col" className="w-32 px-6 py-3">
+              Manage
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {subscribers.map((subscriber) => (
+            <tr
+              className="border-b border-gray-700 bg-gray-800"
+              key={subscriber.xata_id}
+            >
+              <th
+                scope="row"
+                className="whitespace-nowrap px-6 py-4 font-medium text-white"
+              >
+                {subscriber.email}
+              </th>
+              <td className="px-6 py-4">
+                <DeleteButton id={subscriber.xata_id} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   )
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -219,18 +219,6 @@ export async function updateDeal(
   })
 }
 
-export async function incrementDealClicks(id: string): Promise<Deal> {
-  return await prisma.deal.update({
-    where: {
-      xata_id: id,
-    },
-    data: {
-      clicks: {
-        increment: 1,
-      },
-    },
-  })
-}
 export async function getApprovedFeaturedDeals(
   limit: number = 20
 ): Promise<DealWithTags[]> {

--- a/src/queries/dealView.ts
+++ b/src/queries/dealView.ts
@@ -1,0 +1,28 @@
+import prisma from '@/lib/db'
+import { greaterThan } from '@xata.io/client'
+
+export const createDealView = async (dealId: string) => {
+  return await prisma.dealView.create({
+    data: {
+      dealId,
+    },
+  })
+}
+
+export const getViewsByDeal = async (take: number = 20) => {
+  return await prisma.deal.findMany({
+    select: {
+      _count: {
+        select: { views: true },
+      },
+      name: true,
+      xata_id: true,
+    },
+    orderBy: {
+      views: {
+        _count: 'desc',
+      },
+    },
+    take,
+  })
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -40,7 +40,10 @@ const config = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate')],
+  plugins: [
+    require('tailwindcss-animate'),
+    require('@tailwindcss/container-queries'),
+  ],
 } satisfies Config
 
 export default config


### PR DESCRIPTION
- tracking deal views in separate table (instead of with `clicks` property in `Deals` table to enable deeper reporting in the future
- display deals by views in admin dashboard
- reconfigured dashboard pages to use shared `DashboardPage` components
- using tables for displaying dashboard data

## Screenshot
https://github.com/user-attachments/assets/4e552035-81cb-4e7e-a36d-c3e57092db55


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->