### PR TITLE
fix: dont display coupon percent unless greater than 0

### DIFF
--- a/src/components/deals/DealDetails.tsx
+++ b/src/components/deals/DealDetails.tsx
@@ -40,7 +40,7 @@ export default function DealDetails({ deal }: DealDetailsProps) {
                 'No coupon code required'}
             </span>
           </div>
-          {deal.couponPercent && (
+          {deal.couponPercent && deal.couponPercent > 0 && (
             <div className="flex flex-wrap gap-2 text-lg font-light md:mt-1.5">
               <span className="w-40 text-white/70">Discount:</span>
               <span className="font-bold">


### PR DESCRIPTION
Don't display coupon percent unless it is greater than 0