### PR TITLE
fix: no hover on deal details name

### DIFF
--- a/src/components/deals/DealDetails.tsx
+++ b/src/components/deals/DealDetails.tsx
@@ -15,7 +15,7 @@ export default function DealDetails({ deal }: DealDetailsProps) {
       <div className="mb-10">
         <p className="mb-2 font-bold  text-teal-500">{deal.category || ''}</p>
         <div className="mb-10 flex flex-row items-end justify-between gap-x-4">
-          <h1 className="inline text-2xl transition-colors hover:text-teal-500 md:text-3xl">
+          <h1 className="inline text-2xl transition-colors md:text-3xl">
             {deal.name}
           </h1>
           <a


### PR DESCRIPTION
## Description
Deal name on details page had a hover effect even though it wasn't clickable.

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section