### PR TITLE
FEAT: reorganize admin deal edit route

### DIFF
--- a/src/app/(admin)/dashboard/deals/[id]/edit/page.tsx
+++ b/src/app/(admin)/dashboard/deals/[id]/edit/page.tsx
@@ -1,0 +1,29 @@
+import { notFound } from 'next/navigation'
+import { getDealByIdAsAdmin } from '@/lib/queries'
+import EditDealForm from '@/components/dashboard/EditDealForm'
+import DeleteDealButton from '@/components/dashboard/DeleteDealButton'
+import PageHeader from '@/components/PageHeader'
+
+export default async function EditDealPage({
+  params: { id },
+}: {
+  params: { id: string }
+}) {
+  if (!id) {
+    notFound()
+  }
+  const deal = await getDealByIdAsAdmin(id)
+  if (!deal) {
+    notFound()
+  }
+
+  return (
+    <section className="mx-auto max-w-[800px] pb-20">
+      <div className="mb-10 flex flex-col items-center justify-between gap-y-4 sm:flex-row ">
+        <PageHeader heading="Edit Deal" />
+        <DeleteDealButton id={id} />
+      </div>
+      <EditDealForm deal={deal} />
+    </section>
+  )
+}

--- a/src/app/(admin)/dashboard/deals/[id]/edit/page.tsx
+++ b/src/app/(admin)/dashboard/deals/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import { getDealByIdAsAdmin } from '@/lib/queries'
 import EditDealForm from '@/components/dashboard/EditDealForm'
 import DeleteDealButton from '@/components/dashboard/DeleteDealButton'
 import PageHeader from '@/components/PageHeader'
+import Section from '@/components/Section'
 
 export default async function EditDealPage({
   params: { id },
@@ -18,12 +19,12 @@ export default async function EditDealPage({
   }
 
   return (
-    <section className="mx-auto max-w-[800px] pb-20">
+    <Section>
       <div className="mb-10 flex flex-col items-center justify-between gap-y-4 sm:flex-row ">
         <PageHeader heading="Edit Deal" />
         <DeleteDealButton id={id} />
       </div>
       <EditDealForm deal={deal} />
-    </section>
+    </Section>
   )
 }

--- a/src/app/(admin)/dashboard/deals/[id]/page.tsx
+++ b/src/app/(admin)/dashboard/deals/[id]/page.tsx
@@ -3,6 +3,7 @@ import { getDealByIdAsAdmin } from '@/lib/queries'
 import DealDetails from '@/components/deals/DealDetails'
 import { Button } from '@/components/ui/button'
 import Link from 'next/link'
+import Section from '@/components/Section'
 
 export default async function ViewDealAdminPage({
   params: { id },
@@ -18,12 +19,12 @@ export default async function ViewDealAdminPage({
   }
 
   return (
-    <main className="mx-auto max-w-[800px] pb-20">
+    <Section>
       <div className="mb-10 flex flex-col items-center justify-between gap-y-4 sm:flex-row ">
         <h1 className="text-center text-5xl text-white">{deal.name}</h1>
         <Link href={`/dashboard/deals/${deal.xata_id}/edit`}>Edit Deal</Link>
       </div>
       <DealDetails deal={deal} />
-    </main>
+    </Section>
   )
 }

--- a/src/app/(admin)/dashboard/deals/[id]/page.tsx
+++ b/src/app/(admin)/dashboard/deals/[id]/page.tsx
@@ -1,43 +1,10 @@
 import { notFound } from 'next/navigation'
 import { getDealByIdAsAdmin } from '@/lib/queries'
-import { Metadata, ResolvingMetadata } from 'next'
-import EditDealForm from '@/components/dashboard/EditDealForm'
-import DeleteDealButton from '@/components/dashboard/DeleteDealButton'
-import ApproveDealButton from '@/components/dashboard/ApproveDealButton'
+import DealDetails from '@/components/deals/DealDetails'
+import { Button } from '@/components/ui/button'
+import Link from 'next/link'
 
-export const revalidate = 120
-
-type Props = {
-  params: { id: string }
-  searchParams: { [key: string]: string | string[] | undefined }
-}
-
-export async function generateMetadata(
-  { params, searchParams }: Props,
-  parent: ResolvingMetadata
-): Promise<Metadata> {
-  // read route params
-  const id = params.id
-
-  // fetch data
-  const deal = await getDealByIdAsAdmin(params.id)
-
-  if (!deal) {
-    return {
-      title: 'Deal not found',
-    }
-  }
-
-  return {
-    title: deal?.name,
-    description: deal?.description,
-    openGraph: {
-      images: [deal?.coverImageURL || '/logo-wide.png'],
-    },
-  }
-}
-
-export default async function EditDealPage({
+export default async function ViewDealAdminPage({
   params: { id },
 }: {
   params: { id: string }
@@ -51,12 +18,12 @@ export default async function EditDealPage({
   }
 
   return (
-    <section>
+    <main className="mx-auto max-w-[800px] pb-20">
       <div className="mb-10 flex flex-col items-center justify-between gap-y-4 sm:flex-row ">
-        <h1 className="text-center text-5xl text-white">Edit Deal</h1>
-        <DeleteDealButton id={id} />
+        <h1 className="text-center text-5xl text-white">{deal.name}</h1>
+        <Link href={`/dashboard/deals/${deal.xata_id}/edit`}>Edit Deal</Link>
       </div>
-      <EditDealForm deal={deal} />
-    </section>
+      <DealDetails deal={deal} />
+    </main>
   )
 }

--- a/src/app/(public-pages)/deals/[id]/page.tsx
+++ b/src/app/(public-pages)/deals/[id]/page.tsx
@@ -48,7 +48,7 @@ export default async function DealPage({ params }: { params: { id: string } }) {
   }
 
   return (
-    <main className="mx-auto max-w-[800px] pb-20">
+    <main className="pb-20">
       <DealDetails deal={deal} />
     </main>
   )

--- a/src/app/(public-pages)/deals/[id]/page.tsx
+++ b/src/app/(public-pages)/deals/[id]/page.tsx
@@ -48,10 +48,8 @@ export default async function DealPage({ params }: { params: { id: string } }) {
   }
 
   return (
-    <main>
-      <div className="pb-10">
-        <DealDetails deal={deal} />
-      </div>
+    <main className="mx-auto max-w-[800px] pb-20">
+      <DealDetails deal={deal} />
     </main>
   )
 }

--- a/src/components/dashboard/AdminDealsList.tsx
+++ b/src/components/dashboard/AdminDealsList.tsx
@@ -47,7 +47,7 @@ export default function AdminDealsList({ deals }: { deals: Deal[] }) {
                 </div>
                 <Link
                   className="transition-colors hover:text-teal-500"
-                  href={`/deals/${deal.xata_id}`}
+                  href={`/dashboard/deals/${deal.xata_id}`}
                 >
                   {deal.name}
                 </Link>

--- a/src/components/dashboard/DashboardPage.tsx
+++ b/src/components/dashboard/DashboardPage.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import PageHeader from '../PageHeader'
+import Section from '../Section'
 
 interface DashboardCardProps {
   children?: React.ReactNode
@@ -11,9 +12,9 @@ export default function DashboardCard({
   heading,
 }: DashboardCardProps) {
   return (
-    <section>
+    <Section>
       <PageHeader heading={heading} />
       {children}
-    </section>
+    </Section>
   )
 }

--- a/src/components/deals/DealDetails.tsx
+++ b/src/components/deals/DealDetails.tsx
@@ -11,7 +11,7 @@ interface DealDetailsProps {
 }
 export default function DealDetails({ deal }: DealDetailsProps) {
   return (
-    <div className=" mx-auto max-w-[800px] text-white">
+    <div className="  text-white">
       <div className="mb-10">
         <p className="mb-2 font-bold  text-teal-500">{deal.category || ''}</p>
         <div className="mb-10 flex flex-row items-end justify-between gap-x-4">


### PR DESCRIPTION
## Description

- move dashboard deal edit route to `/dashboard/deals/[id]/edit`
- add dashboard deal details page at `/dashboard/deals/[id]`
- remove unnecessary metadata generation
- use `Section` component for dashboard pages

## Issue
<!-- If this PR is related to a specific issue, please list that here. (e.g - "Closes or Relates to: # XXXX") -->

## Screenshot
https://github.com/user-attachments/assets/44417196-3e12-4fab-a719-73bed5fbb9fd


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section
