### PR TITLE
fix: overlay opens and closes appropritately

### DIFF
--- a/src/components/Overlay.tsx
+++ b/src/components/Overlay.tsx
@@ -17,13 +17,17 @@ const Overlay = ({
   className?: string
 }) => {
   const dialogRef = useRef<HTMLDialogElement>(null)
-  useHotkeys('esc', onClose)
+  useHotkeys('esc', () => {
+    onClose()
+  })
 
   useEffect(() => {
     if (isOpen) {
       dialogRef.current?.showModal()
+      document.body.style.overflow = 'hidden'
     } else {
       dialogRef.current?.close()
+      document.body.style.overflow = 'unset'
     }
   })
   return (

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -22,7 +22,7 @@ export default function GlobalSearch() {
     inputRef?.current?.focus()
   }
 
-  const closeSearch = () => {
+  const onClose = () => {
     setSearchOpen(false)
     setSearchQuery('')
     setDeals(null)
@@ -64,7 +64,7 @@ export default function GlobalSearch() {
   }
 
   return (
-    <Overlay isOpen={searchOpen} onClose={closeSearch} className="h-[90vh]">
+    <Overlay isOpen={searchOpen} onClose={onClose} className="h-[90vh]">
       <div className="flex h-full flex-col">
         <div className="relative">
           <input

--- a/src/components/search/GlobalSearch.tsx
+++ b/src/components/search/GlobalSearch.tsx
@@ -17,24 +17,16 @@ export default function GlobalSearch() {
   const [loading, setLoading] = useState(false)
   const inputRef = useRef<null | HTMLInputElement>(null)
 
-  useEffect(() => {
-    inputRef?.current?.focus()
-  }, [searchOpen])
-
   const openSearch = () => {
     setSearchOpen(true)
-    document.body.style.overflow = 'hidden'
     inputRef?.current?.focus()
   }
 
-  const reset = () => {
+  const closeSearch = () => {
     setSearchOpen(false)
     setSearchQuery('')
     setDeals(null)
-    document.body.style.overflow = 'unset'
   }
-
-  useHotkeys('esc', reset)
 
   useHotkeys('/', openSearch, {
     preventDefault: true,
@@ -72,7 +64,7 @@ export default function GlobalSearch() {
   }
 
   return (
-    <Overlay isOpen={searchOpen} onClose={reset} className="h-[90vh]">
+    <Overlay isOpen={searchOpen} onClose={closeSearch} className="h-[90vh]">
       <div className="flex h-full flex-col">
         <div className="relative">
           <input


### PR DESCRIPTION
Search overlay failed to open a second time (after closing once)

## Description
- overlays handles `esc` key press and calls `onClose` function
- remove `esc` key handler in `GlobalSearch`
- move body overflow styles to `Overlay` so there is not scroll any time it is used

## Issue
Closes #250 

## Screenshot

https://github.com/user-attachments/assets/7e10a5d2-3d12-4e7f-a454-6f4bf8767a77

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [ ] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->