### PR TITLE
fix(loading): match loading states with deal details

### DIFF
--- a/src/components/deals/loading/LoadingPreview.tsx
+++ b/src/components/deals/loading/LoadingPreview.tsx
@@ -1,11 +1,65 @@
+import Section, { SECTION_STYLE, SECTION_WIDTH } from '@/components/Section'
 import LoadingDealImage from './LoadingDealImage'
-
+import LoadingTagsList from './LoadingTagsList'
+import LoadingText, {
+  LOADING_TEXT_STYLE,
+  LOADING_TEXT_WIDHTS,
+} from './LoadingText'
 export default function LoadingPreview() {
   return (
-    <div className="flex flex-col items-start gap-10 text-white xl:flex-row xl:items-center">
-      <div className="align-center relative aspect-video w-full max-w-[600px] self-center">
-        <LoadingDealImage />
-      </div>
+    <div>
+      <Section
+        width={SECTION_WIDTH.SM}
+        className="pb-32 text-gray-700 sm:pb-40 md:pb-80"
+      >
+        <div className="mb-10">
+          <LoadingText className="mb-2  font-bold" />
+          <div className="mb-10 flex flex-row items-end justify-between gap-x-4">
+            <LoadingText
+              className="text-2xl md:text-3xl"
+              width={LOADING_TEXT_WIDHTS.LARGE}
+            />
+            <LoadingText
+              className="px-2 py-1"
+              width={LOADING_TEXT_WIDHTS.SMALL}
+            ></LoadingText>
+          </div>
+
+          <LoadingText
+            width={LOADING_TEXT_WIDHTS.MEDIUM}
+            className="mb-4 font-bold"
+          />
+          <LoadingText
+            width={LOADING_TEXT_WIDHTS.SMALL}
+            className="mb-4 font-bold"
+          />
+          <LoadingTagsList />
+        </div>
+      </Section>
+
+      <Section
+        style={SECTION_STYLE.LIGHT}
+        width={SECTION_WIDTH.SM}
+        className="-mb-40 md:-mb-64"
+      >
+        <div className="-translate-y-48 md:-translate-y-80">
+          <div className="relative mx-auto aspect-video w-full ">
+            <LoadingDealImage />
+          </div>
+
+          <div className="text-md mb-10 mt-5 flex w-full flex-col items-start gap-y-1 md:mt-10 md:text-lg">
+            <LoadingText
+              style={LOADING_TEXT_STYLE.LIGHT}
+              className="font-bold uppercase"
+            ></LoadingText>
+
+            <LoadingText
+              style={LOADING_TEXT_STYLE.LIGHT}
+              className="h-40 w-full whitespace-pre-wrap font-light"
+            />
+          </div>
+        </div>
+      </Section>
     </div>
   )
 }

--- a/src/components/deals/loading/LoadingPreview.tsx
+++ b/src/components/deals/loading/LoadingPreview.tsx
@@ -5,6 +5,7 @@ import LoadingText, {
   LOADING_TEXT_STYLE,
   LOADING_TEXT_WIDHTS,
 } from './LoadingText'
+
 export default function LoadingPreview() {
   return (
     <div>

--- a/src/components/deals/loading/LoadingTag.tsx
+++ b/src/components/deals/loading/LoadingTag.tsx
@@ -1,0 +1,6 @@
+import React from 'react'
+import LoadingText, { LOADING_TEXT_WIDHTS } from './LoadingText'
+
+export default function LoadingTag() {
+  return <LoadingText width={LOADING_TEXT_WIDHTS.XS} className="px-3 py-2" />
+}

--- a/src/components/deals/loading/LoadingTagsList.tsx
+++ b/src/components/deals/loading/LoadingTagsList.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import LoadingTag from './LoadingTag'
+
+export default function LoadingTagsList() {
+  const arr = Array.from(Array(3).keys())
+
+  return (
+    <div className="flex flex-wrap gap-x-2 gap-y-4">
+      {arr.map((tag, index) => (
+        <LoadingTag key={index} />
+      ))}
+    </div>
+  )
+}

--- a/src/components/deals/loading/LoadingText.tsx
+++ b/src/components/deals/loading/LoadingText.tsx
@@ -1,0 +1,32 @@
+import { cn } from '@/lib/utils'
+import React from 'react'
+
+interface LoadingTextProps {
+  className?: string
+  width?: LOADING_TEXT_WIDHTS
+  style?: LOADING_TEXT_STYLE
+}
+
+export enum LOADING_TEXT_WIDHTS {
+  XS = 'w-10',
+  SMALL = 'w-20',
+  MEDIUM = 'w-40',
+  LARGE = 'w-60',
+}
+
+export enum LOADING_TEXT_STYLE {
+  DARK = 'bg-gray-700 text-gray-700',
+  LIGHT = 'bg-gray-200 text-gray-200',
+}
+
+export default function LoadingText({
+  className,
+  width = LOADING_TEXT_WIDHTS.MEDIUM,
+  style = LOADING_TEXT_STYLE.DARK,
+}: LoadingTextProps) {
+  return (
+    <div className={cn('animate-pulse rounded-md', width, style, className)}>
+      l
+    </div>
+  )
+}


### PR DESCRIPTION
Update loading states for deal details to match the `DealDetails.tsx` component

## Description
- added `LoadingText` component with properties for width and style
- added loading components for Tags

## Issue
Closes #248 

## Screenshot

https://github.com/user-attachments/assets/271b9ad6-c391-4ff0-b8cf-f1b8ba437f07


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->