### PR TITLE
feat: added category counts to category options

### DIFF
--- a/src/app/(public-pages)/deals/category/[category]/layout.tsx
+++ b/src/app/(public-pages)/deals/category/[category]/layout.tsx
@@ -1,0 +1,28 @@
+import CategoryOptions from '@/components/CategoryOptions'
+import Container from '@/components/Container'
+import PageHeader from '@/components/PageHeader'
+import { Category } from '@/types/Types'
+
+export default async function CategoryLayout({
+  children,
+  params,
+}: {
+  params: { category: string }
+  children: React.ReactNode
+}) {
+  const category = decodeURIComponent(params.category).toUpperCase()
+
+  return (
+    <Container className="pb-20">
+      <PageHeader heading="Deals" />
+      <div className="pb-10">
+        <CategoryOptions
+          selectedCategory={
+            category !== 'all' ? (category as Category) : undefined
+          }
+        />
+      </div>
+      <main>{children}</main>
+    </Container>
+  )
+}

--- a/src/app/(public-pages)/deals/category/[category]/page.tsx
+++ b/src/app/(public-pages)/deals/category/[category]/page.tsx
@@ -1,13 +1,8 @@
-import CategoryOptions from '@/components/CategoryOptions'
 import { redirect } from 'next/navigation'
 import { Category } from '@/types/Types'
-import { getApprovedDealsByCategory } from '@/lib/queries'
-import PageHeader from '@/components/PageHeader'
-import DealsList from '@/components/deals/DealsList'
 import ApprovedDealsByCategory from '@/components/deals/ApprovedDealsByCategory'
 import { Suspense } from 'react'
 import LoadingDealsList from '@/components/deals/loading/LoadingDealsList'
-import Container from '@/components/Container'
 
 export const revalidate = 120
 
@@ -22,29 +17,14 @@ export default async function CategoryPage({
 
   const categoryString = decodeURIComponent(params.category).toUpperCase()
 
-  if (Object.keys(Category).indexOf(categoryString as Category) === -1) {
+  if (!(categoryString in Category)) {
     redirect('/')
   }
-  //TODO move logic for converting deals to capitalized and singular to a helper function
   const category = categoryString as Category
-  let capitalizedCategory = category
-    .split(' ')
-    .map((word) => word.charAt(0).toUpperCase() + word.toLowerCase().slice(1))
-    .join(' ')
-  if (capitalizedCategory.endsWith('s')) {
-    capitalizedCategory = capitalizedCategory.slice(0, -1)
-  }
+
   return (
-    <Container>
-      <main>
-        <PageHeader heading={`${capitalizedCategory} Deals`} />
-        <div className="pb-10">
-          <CategoryOptions />
-        </div>
-        <Suspense fallback={<LoadingDealsList count={3} />}>
-          <ApprovedDealsByCategory category={category} />
-        </Suspense>
-      </main>
-    </Container>
+    <Suspense fallback={<LoadingDealsList count={3} />}>
+      <ApprovedDealsByCategory category={category} />
+    </Suspense>
   )
 }

--- a/src/app/(public-pages)/deals/page.tsx
+++ b/src/app/(public-pages)/deals/page.tsx
@@ -9,19 +9,17 @@ import { Suspense } from 'react'
 export const revalidate = 120
 
 export default async function DealsPage() {
-  //TODO: handle error
   return (
-    <Container>
-      <main>
-        <PageHeader heading="All Deals" />
-        <div className="pb-10">
-          <CategoryOptions />
-        </div>
-        <Suspense fallback={<LoadingDealsList count={3} />}>
-          <ApprovedDeals />
-        </Suspense>
-        <NeverMissADeal />
-      </main>
+    <Container className="pb-20">
+      <PageHeader heading="Deals" />
+      <div className="pb-10">
+        <CategoryOptions selectedCategory={undefined} />
+      </div>
+
+      <Suspense fallback={<LoadingDealsList count={3} />}>
+        <ApprovedDeals />
+      </Suspense>
+      <NeverMissADeal />
     </Container>
   )
 }

--- a/src/components/CategoryOption.tsx
+++ b/src/components/CategoryOption.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import Link from 'next/link'
 import React from 'react'
 import { twMerge } from 'tailwind-merge'
@@ -6,22 +7,32 @@ export default function CategoryOption({
   category,
   path,
   selected = false,
+  count,
 }: {
   category: string
   path?: string
   selected?: boolean
+  count: number
 }) {
   return (
     <Link
       href={path || `/deals/category/${category}`}
       className={twMerge(
-        'rounded-full  border border-white px-4 py-2 text-white transition-colors duration-300 ease-in-out hover:border-teal-500 hover:text-teal-500',
+        'flex items-center gap-x-2 rounded-full border border-white px-4 py-2 text-white transition-colors duration-300 ease-in-out hover:border-teal-500 hover:text-teal-500',
         selected ?
           'text-primary hover:text-primary border-teal-500 bg-teal-500'
         : ''
       )}
     >
-      {category}
+      <span>{category}</span>
+      <span
+        className={cn(
+          `rounded-full bg-teal-700 px-2 text-sm text-teal-100  `,
+          {}
+        )}
+      >
+        {count}
+      </span>
     </Link>
   )
 }

--- a/src/components/CategoryOptions.tsx
+++ b/src/components/CategoryOptions.tsx
@@ -1,26 +1,38 @@
-'use client'
 import { Category } from '@/types/Types'
 import CategoryOption from './CategoryOption'
-import { usePathname } from 'next/navigation'
+import { getDealCategoryCounts, getTotaylApprovedDeals } from '@/lib/queries'
 
-export default function CategoryOptions() {
-  const pathname = usePathname()
-  const lastRoute = pathname.split('/').pop()
+interface CategoryOptionsProps {
+  selectedCategory?: Category
+}
+export default async function CategoryOptions({
+  selectedCategory,
+}: CategoryOptionsProps) {
+  const categoryCounts = await getDealCategoryCounts()
+  const totalDeals = await getTotaylApprovedDeals()
+
   return (
     <div>
       <div className="flex flex-wrap items-center gap-4">
         <CategoryOption
-          category="all"
+          category="ALL"
           path="/deals"
-          selected={lastRoute?.toLowerCase() === 'deals'}
+          count={totalDeals}
+          selected={!selectedCategory}
         />
-        {Object.values(Category).map((category) => (
-          <CategoryOption
-            category={category}
-            key={category}
-            selected={lastRoute?.toLowerCase() == category.toLowerCase()}
-          />
-        ))}
+        {categoryCounts
+          .filter((categoryCount) => categoryCount.count > 0)
+          .map((categoryCount) => (
+            <CategoryOption
+              category={categoryCount.category}
+              key={categoryCount.category}
+              count={categoryCount.count}
+              selected={
+                selectedCategory?.toUpperCase() ==
+                categoryCount.category.toUpperCase()
+              }
+            />
+          ))}
       </div>
     </div>
   )

--- a/src/components/deals/ApprovedDealsByCategory.tsx
+++ b/src/components/deals/ApprovedDealsByCategory.tsx
@@ -9,6 +9,5 @@ export default async function ApprovedDealsByCategory({
   category: Category
 }) {
   const deals = await getApprovedDealsByCategory(category)
-
   return <DealsList deals={deals} />
 }

--- a/src/lib/queries.ts
+++ b/src/lib/queries.ts
@@ -166,6 +166,51 @@ export async function getApprovedDealsByCategory(
   })
 }
 
+export async function getDealCategoryCounts(): Promise<
+  { category: Category; count: number }[]
+> {
+  const res = await prisma.deal.groupBy({
+    by: ['category'],
+    _count: true,
+    where: {
+      approved: true,
+      OR: [
+        {
+          endDate: {
+            gte: new Date(),
+          },
+        },
+        { endDate: null },
+      ],
+    },
+  })
+
+  return res
+    .filter((record) => record.category in Category)
+    .map((record) => {
+      return {
+        count: record._count,
+        category: record.category as Category,
+      }
+    })
+}
+
+export const getTotaylApprovedDeals = async () => {
+  return await prisma.deal.count({
+    where: {
+      approved: true,
+      OR: [
+        {
+          endDate: {
+            gte: new Date(),
+          },
+        },
+        { endDate: null },
+      ],
+    },
+  })
+}
+
 //TODO: get a type from prisma for new deal
 export const createDeal = async (newDeal: any) => {
   const data = await prisma.deal.create({


### PR DESCRIPTION

## Description
Show number of deals by category and don't show category options that don't have any deals.


## Screenshot
![CleanShot 2024-08-30 at 13 18 49](https://github.com/user-attachments/assets/07b4e0ba-7bb6-46b3-88a1-127f50c420b1)

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->