### PR TITLE
fix: display discount on deal details

### DIFF
--- a/src/components/deals/details/DealDetails.tsx
+++ b/src/components/deals/details/DealDetails.tsx
@@ -68,6 +68,7 @@ export default function DealDetails({ deal }: DealDetailsProps) {
               name={deal.name}
               coverImageURL={deal.coverImageURL || null}
               category={deal.category as Category}
+              couponPercent={deal.couponPercent || undefined}
             />
           </div>
 


### PR DESCRIPTION
Deal details page was missing the discount overlay on the deal image because the `couponPercent` prop was not being  passed.

## Description
Added the `couponPercent` prop to the `DealDetails` component.


## Screenshot
![CleanShot 2024-09-01 at 07 26 38](https://github.com/user-attachments/assets/51ab32c4-23c4-4b7e-907f-758dcdcc5909)

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section
