### PR TITLE
feat: refactor `LoadingText` to use `lh`

### DIFF
--- a/src/app/(public-pages)/deals/[id]/page.tsx
+++ b/src/app/(public-pages)/deals/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function DealPage({ params }: { params: { id: string } }) {
 
   return (
     <main className="pb-20">
-      <Section width={SECTION_WIDTH.SM} className="">
+      <Section>
         <DealDetails deal={deal} />
 
         <div className="space-between flex flex-col justify-between gap-4 sm:flex-row">

--- a/src/components/deals/details/DealDetails.tsx
+++ b/src/components/deals/details/DealDetails.tsx
@@ -5,7 +5,6 @@ import TagsList from '../../forms/add-a-deal/TagsList'
 import ClickableCoupon from '../../ClickableCouponCode'
 import { format } from 'date-fns'
 import Image from 'next/image'
-import Section, { SECTION_WIDTH } from '../../Section'
 
 interface DealDetailsProps {
   deal: DealWithTags
@@ -36,15 +35,15 @@ export default function DealDetails({ deal }: DealDetailsProps) {
           </a>
         </div>
 
-        <div className="text-md mb-4 font-light md:text-lg">
-          <div className="mb-1 flex flex-wrap gap-2">
+        <div className="mb-4 font-light">
+          <div className="text-md mb-1 flex flex-wrap gap-2 md:text-lg">
             <span className="w-40 text-white/70 ">Valid from:</span>
             <span className="font-bold">
               {`${format(new Date(deal.startDate), 'MMM d, yyyy')} - ${deal.endDate ? format(new Date(deal.endDate), 'MMM d, yyyy') : '(no end date)'}` ||
                 'No coupon code required'}
             </span>
           </div>
-          <div className="mb-4 flex flex-wrap gap-2 text-lg font-light md:mt-1.5">
+          <div className="text-md mb-4 flex flex-wrap  gap-2 font-light md:text-lg">
             <span className="w-40 text-white/70">Coupon Code:</span>
             <span className="font-bold">
               {deal.coupon ?

--- a/src/components/deals/loading/LoadingDealImage.tsx
+++ b/src/components/deals/loading/LoadingDealImage.tsx
@@ -1,5 +1,5 @@
 export default function LoadingDealImage() {
   return (
-    <div className=" flex aspect-video w-full animate-pulse items-center justify-center rounded-xl border-4 border-slate-500 bg-gray-100"></div>
+    <div className="flex aspect-video w-full animate-pulse items-center justify-center rounded-xl border-4 border-slate-600 bg-gray-700"></div>
   )
 }

--- a/src/components/deals/loading/LoadingPreview.tsx
+++ b/src/components/deals/loading/LoadingPreview.tsx
@@ -1,66 +1,46 @@
-import Section, { SECTION_STYLE, SECTION_WIDTH } from '@/components/Section'
+import Section from '@/components/Section'
 import LoadingDealImage from './LoadingDealImage'
 import LoadingTagsList from './LoadingTagsList'
-import LoadingText, {
-  LOADING_TEXT_STYLE,
-  LOADING_TEXT_WIDHTS,
-} from './LoadingText'
+import LoadingText, { LOADING_TEXT_WIDTHS } from './LoadingText'
 
 export default function LoadingPreview() {
   return (
-    <div>
-      <Section
-        width={SECTION_WIDTH.SM}
-        className="pb-32 text-gray-700 sm:pb-40 md:pb-80"
-      >
+    <Section className="opacity-65">
+      <div className="text-gray-700 ">
         <div className="mb-10">
-          <LoadingText className="mb-2  font-bold" />
+          <LoadingText className="mb-2 font-bold" />
           <div className="mb-10 flex flex-row items-end justify-between gap-x-4">
             <LoadingText
               className="text-2xl md:text-3xl"
-              width={LOADING_TEXT_WIDHTS.LARGE}
+              width={LOADING_TEXT_WIDTHS.LARGE}
             />
             <LoadingText
-              className="px-2 py-1"
-              width={LOADING_TEXT_WIDHTS.SMALL}
+              className="rounded-md px-2 py-1"
+              width={LOADING_TEXT_WIDTHS.SMALL}
             ></LoadingText>
           </div>
 
           <LoadingText
-            width={LOADING_TEXT_WIDHTS.MEDIUM}
-            className="mb-4 font-bold"
+            width={LOADING_TEXT_WIDTHS.MEDIUM}
+            className="text-md mb-1 font-bold md:text-lg"
           />
           <LoadingText
-            width={LOADING_TEXT_WIDHTS.SMALL}
-            className="mb-4 font-bold"
+            width={LOADING_TEXT_WIDTHS.SMALL}
+            className="text-md mb-4 font-bold md:text-lg"
           />
           <LoadingTagsList />
         </div>
-      </Section>
 
-      <Section
-        style={SECTION_STYLE.LIGHT}
-        width={SECTION_WIDTH.SM}
-        className="-mb-40 md:-mb-64"
-      >
-        <div className="-translate-y-48 md:-translate-y-80">
-          <div className="relative mx-auto aspect-video w-full ">
-            <LoadingDealImage />
-          </div>
-
-          <div className="text-md mb-10 mt-5 flex w-full flex-col items-start gap-y-1 md:mt-10 md:text-lg">
-            <LoadingText
-              style={LOADING_TEXT_STYLE.LIGHT}
-              className="font-bold uppercase"
-            ></LoadingText>
-
-            <LoadingText
-              style={LOADING_TEXT_STYLE.LIGHT}
-              className="h-40 w-full whitespace-pre-wrap font-light"
-            />
-          </div>
+        <div className="relative mx-auto aspect-video w-full">
+          <LoadingDealImage />
         </div>
-      </Section>
-    </div>
+
+        <div className="text-md mb-10 mt-5 flex w-full flex-col items-start gap-y-1 md:mt-10 md:text-lg">
+          <LoadingText className="font-bold"></LoadingText>
+
+          <LoadingText className="h-40 w-full" />
+        </div>
+      </div>
+    </Section>
   )
 }

--- a/src/components/deals/loading/LoadingTag.tsx
+++ b/src/components/deals/loading/LoadingTag.tsx
@@ -1,6 +1,11 @@
 import React from 'react'
-import LoadingText, { LOADING_TEXT_WIDHTS } from './LoadingText'
+import LoadingText, { LOADING_TEXT_WIDTHS } from './LoadingText'
 
 export default function LoadingTag() {
-  return <LoadingText width={LOADING_TEXT_WIDHTS.XS} className="px-3 py-2" />
+  return (
+    <LoadingText
+      width={LOADING_TEXT_WIDTHS.XS}
+      className="border-1 rounded-2xl border-gray-700 px-3 py-2"
+    />
+  )
 }

--- a/src/components/deals/loading/LoadingText.tsx
+++ b/src/components/deals/loading/LoadingText.tsx
@@ -3,11 +3,11 @@ import React from 'react'
 
 interface LoadingTextProps {
   className?: string
-  width?: LOADING_TEXT_WIDHTS
+  width?: LOADING_TEXT_WIDTHS
   style?: LOADING_TEXT_STYLE
 }
 
-export enum LOADING_TEXT_WIDHTS {
+export enum LOADING_TEXT_WIDTHS {
   XS = 'w-10',
   SMALL = 'w-20',
   MEDIUM = 'w-40',
@@ -21,12 +21,17 @@ export enum LOADING_TEXT_STYLE {
 
 export default function LoadingText({
   className,
-  width = LOADING_TEXT_WIDHTS.MEDIUM,
+  width = LOADING_TEXT_WIDTHS.MEDIUM,
   style = LOADING_TEXT_STYLE.DARK,
 }: LoadingTextProps) {
   return (
-    <div className={cn('animate-pulse rounded-md', width, style, className)}>
-      l
-    </div>
+    <div
+      className={cn(
+        'box-content h-[1lh] animate-pulse rounded-md ',
+        width,
+        style,
+        className
+      )}
+    ></div>
   )
 }


### PR DESCRIPTION
`LoadingText` component was using invisible text to maintain height. Now, we are using the `lh` unit for height which automatically calculates the height of the element as if there was text present. This way, we can get rid of invisible text.

## Screenshot
Loading state should look basically the same as it was.
https://github.com/user-attachments/assets/656a15f4-ab6b-4efd-972d-d95c59cfffba

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->