### PR TITLE
fix: remove button variant from calendar

### DIFF
--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -37,10 +37,7 @@ function Calendar({
           'text-slate-500 rounded-md w-9 font-normal text-[0.8rem] dark:text-slate-400',
         row: 'flex w-full mt-2',
         cell: 'h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-slate-100/50 [&:has([aria-selected])]:bg-slate-100 first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20 dark:[&:has([aria-selected].day-outside)]:bg-slate-800/50 dark:[&:has([aria-selected])]:bg-slate-800',
-        day: cn(
-          buttonVariants({ variant: 'ghost-light' }),
-          'h-9 w-9 p-0 font-normal aria-selected:opacity-100'
-        ),
+        day: cn('h-9 w-9 p-0 font-normal aria-selected:opacity-100'),
         day_range_end: 'day-range-end',
         day_selected:
           'bg-slate-900 text-slate-50 hover:bg-slate-900 hover:text-slate-50 focus:bg-slate-900 focus:text-slate-50 dark:bg-slate-50 dark:text-slate-900 dark:hover:bg-slate-50 dark:hover:text-slate-900 dark:focus:bg-slate-50 dark:focus:text-slate-900',


### PR DESCRIPTION
Make sure calendar buttons are visible by removing button variant.

## Screenshot

https://github.com/user-attachments/assets/a9a98a03-7eac-4e5f-b1e0-3e0a79d3b544



## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [x] The `Description` gives a good representation of the changes made
- [x] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->