### PR TITLE
style: position sticky in the DealDetails component

### DIFF
--- a/src/components/deals/details/DealDetails.tsx
+++ b/src/components/deals/details/DealDetails.tsx
@@ -11,7 +11,7 @@ interface DealDetailsProps {
 }
 export default function DealDetails({ deal }: DealDetailsProps) {
   return (
-    <div className="text-white">
+    <div className="sticky top-0 pt-2 text-white">
       <div className="mb-10">
         <p className="mb-2 font-bold  text-teal-500">{deal.category || ''}</p>
         <div className="mb-10 flex flex-row items-end justify-between gap-x-4">


### PR DESCRIPTION
<!-- Thank you for offering your contribution with Deals for Devs! -->

## Description
<!-- Describe your PR's proposed changes. -->
Changing the position to sticky for the component improves the UX. Whenever the user scrolls to the bottom when filling the form, the information on the right sticks with the process itself, being related to the form.

## Screenshot
<!-- Add a screenshot of your contribution here. -->
![image](https://github.com/user-attachments/assets/30282e90-af1c-4359-a516-4dc033f645b8)

## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [ x] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ x] The `Description` gives a good representation of the changes made
- [ ] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->