### PR TITLE
feature: add a custom 404 page for all

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,42 @@
+import Container from '@/components/Container'
+import DevGiveaways from '@/components/DevGiveaways'
+import Footer from '@/components/Footer'
+import Nav from '@/components/nav/Nav'
+import NeverMissADeal from '@/components/NeverMissADeal'
+import PageHeader from '@/components/PageHeader'
+import { SearchProvider } from '@/components/search/SearchContext'
+import Separator from '@/components/Separator'
+import Link from 'next/link'
+import React from 'react'
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-900">
+      <SearchProvider>
+        <Container className="pb-10">
+          <Nav />
+          <main>
+            <PageHeader heading="Sorry, this page isn't available" />
+            <div className='flex flex-wrap text-white text-sm font-light  md:text-lg'>
+              <p className="mr-2">The link you followed may be broken, or the page may have been removed. </p>
+              <Link className=" underline font-semibold"
+                href="/">
+                Back to Home
+              </Link>
+            </div>
+
+            {/* If you want to add these two sections (NeverMissADeal & DevGiveaways) */}
+            {/*  
+            <div className="mb-20">
+              <NeverMissADeal />
+            </div>
+            <Separator className="mx-6 mb-20 md:mx-0" />
+            <DevGiveaways /> */}
+
+          </main>
+        </Container>
+        <Footer />
+      </SearchProvider>
+    </div>
+  )
+}


### PR DESCRIPTION
[https://github.com/Learn-Build-Teach/deals-for-devs/pull/286]


Solving #247

## Description

Previously a 404 page was added but it was only for individual deals.
But this time i make one for all pages accept deals (as it was already made)

[https://nextjs.org/docs/app/api-reference/file-conventions/not-found](https://nextjs.org/docs/app/api-reference/file-conventions/not-found)
 

## Issue
<!-- If this PR is related to a specific issue, please list that here. (e.g - "Closes or Relates to: # XXXX") -->
Solving #247

> (can't do it in `dev` branch as some components are missing there.)

## Screenshot
<!-- Add a screenshot of your contribution here. -->

![image](https://github.com/user-attachments/assets/32b890be-3a0d-4caa-9210-689eab4ed5e8)


## PR Requirements
<!-- Add an X in the [ ] if you have done each task -->
- [ x ] I have carefully read through and understand the [Deals-for-Devs Contributing Guide](https://github.com/Learn-Build-Teach/deals-for-devs/blob/dev/.github/contributing.md)
- [ x ] The title of this PR follows the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format
- [ x ] The `Description` gives a good representation of the changes made
- [ x ] If this PR addresses an open Issue, it is linked in the `Issue` section


<!-- If you have any additional thoughts, just add them here. -->